### PR TITLE
[Feat] 작품 수정 API (Mock Data) 추가, 작품 응답 데이터 memberId 추가

### DIFF
--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/artwork/controller/ArtWorkController.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/artwork/controller/ArtWorkController.java
@@ -1,8 +1,8 @@
 package com.codestates.mainproject.oneyearfourcut.domain.artwork.controller;
 
+import com.codestates.mainproject.oneyearfourcut.domain.artwork.dto.ArtWorkListResponseDto;
 import com.codestates.mainproject.oneyearfourcut.domain.artwork.dto.ArtWorkRequestDto;
 import com.codestates.mainproject.oneyearfourcut.domain.artwork.dto.ArtWorkResponseDto;
-import com.codestates.mainproject.oneyearfourcut.domain.artwork.dto.ArtWorkListResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -26,8 +26,8 @@ public class ArtWorkController {
     public ResponseEntity<?> getArtWorks(@PathVariable("gallery-id") long galleryId) {
 
         List<ArtWorkResponseDto> artworks = List.of(
-                new ArtWorkResponseDto(1L, "타이틀1", "설명1", "이미지경로1", 5, true, 3),
-                new ArtWorkResponseDto(2L, "타이틀2", "설명2", "이미지경로2", 3, false, 3)
+                new ArtWorkResponseDto(1L, 1L, "타이틀1", "설명1", "이미지경로1", 5, true, 3),
+                new ArtWorkResponseDto(2L, 1L, "타이틀2", "설명2", "이미지경로2", 3, false, 3)
                 );
 
         ArtWorkListResponseDto response = new ArtWorkListResponseDto("원강님의 전시관", "나의 전시관을 소개합니다!", artworks);
@@ -38,7 +38,19 @@ public class ArtWorkController {
     @GetMapping("{gallery-id}/artworks/{artwork-id}")
     public ResponseEntity<?> getArtWork(@PathVariable("gallery-id") long galleryId,
                                      @PathVariable("artwork-id") long artWorkId) {
-        ArtWorkResponseDto response = new ArtWorkResponseDto(artWorkId, "타이틀1", "설명1", "이미지경로1", 5, false, 3);
+        ArtWorkResponseDto response = new ArtWorkResponseDto(artWorkId, 1L,"타이틀1", "설명1", "이미지경로1", 5, false, 3);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    // 작품 수정
+    @PatchMapping("/{gallery-id}/artworks/{artwork-id}")
+    public ResponseEntity<?> patchArtWork(@PathVariable("gallery-id") long galleryId,
+                                          @PathVariable("artwork-id") long artWorkId,
+                                          @ModelAttribute ArtWorkRequestDto request) {
+        ArtWorkResponseDto response = new ArtWorkResponseDto(artWorkId, 1L,request.getTitle(), request.getContent(),
+                "이미지경로/" + request.getImg().getOriginalFilename(),
+                5, false, 3);
+
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/artwork/dto/ArtWorkResponseDto.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/artwork/dto/ArtWorkResponseDto.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 public class ArtWorkResponseDto {
 
     private long artWorkId;
+    private long memberId;
     private String title;
     private String content;
     private String imagePath;


### PR DESCRIPTION
작품 수정 API 구현 - Mock Data
 1. "이미지경로/" + request.getImg().getOriginalFilename() == "imagePath": "이미지경로/율무.jpeg"와 같이 응답될 예정
작품 관련 응답에 memberId 데이터 추가