### PR TITLE
[BE] Member, Gallery, Vote Controller Mock객체 반환 구현, 관련 dto 구현

### DIFF
--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/gallery/controller/GalleryController.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/gallery/controller/GalleryController.java
@@ -19,9 +19,24 @@ public class GalleryController {
         GalleryResponseDto galleryResponseDto = GalleryResponseDto.builder()
                 .createdAt(LocalDateTime.now())
                 .galleryId(1L)
+                .title(galleryRequestDto.getTitle())
+                .content(galleryRequestDto.getContent())
                 .build();
 
         return new ResponseEntity<>(galleryResponseDto, HttpStatus.CREATED);
+    }
+
+    //전시관 조회
+    @GetMapping("/{gallery-id}")
+    public ResponseEntity getGallery(@PathVariable("gallery-id") Long galleryId) {
+        GalleryResponseDto galleryResponseDto = GalleryResponseDto.builder()
+                .createdAt(LocalDateTime.now())
+                .galleryId(1L)
+                .title("승필의 전시회")
+                .content("어서오세요")
+                .build();
+
+        return new ResponseEntity<>(galleryResponseDto, HttpStatus.OK);
     }
 
     //전시관 수정

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/gallery/controller/GalleryController.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/gallery/controller/GalleryController.java
@@ -1,0 +1,41 @@
+package com.codestates.mainproject.oneyearfourcut.domain.gallery.controller;
+
+import com.codestates.mainproject.oneyearfourcut.domain.gallery.dto.GalleryRequestDto;
+import com.codestates.mainproject.oneyearfourcut.domain.gallery.dto.GalleryResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/galleries")
+public class GalleryController {
+    //전시관 등록
+    @PostMapping
+    public ResponseEntity postGallery(@RequestBody GalleryRequestDto galleryRequestDto) {
+        // jwt 토큰으로 회원id를 조회
+        // 활성화된 전시관이 이미 존재하는지 확인하고 있으면 에러, 없으면 전시관 생성
+        GalleryResponseDto galleryResponseDto = GalleryResponseDto.builder()
+                .createdAt(LocalDateTime.now())
+                .galleryId(1L)
+                .build();
+
+        return new ResponseEntity<>(galleryResponseDto, HttpStatus.CREATED);
+    }
+
+    //전시관 수정
+    @PatchMapping("/{gallery-id}")
+    public ResponseEntity patchGallery(@RequestBody GalleryRequestDto galleryRequestDto,
+                                       @PathVariable("gallery-id") Long galleryId) {
+        // 전시관 편집하는 로직
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
+    //전시관 폐쇄
+    @DeleteMapping("/{gallery-id}")
+    public ResponseEntity deleteGallery(@PathVariable("gallery-id") Long galleryId) {
+        // 전시관 폐쇄하는 로직
+        return new ResponseEntity(HttpStatus.NO_CONTENT);
+    }
+}

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/gallery/dto/GalleryRequestDto.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/gallery/dto/GalleryRequestDto.java
@@ -1,0 +1,11 @@
+package com.codestates.mainproject.oneyearfourcut.domain.gallery.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GalleryRequestDto {
+    private String title;
+    private String content;
+}

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/gallery/dto/GalleryResponseDto.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/gallery/dto/GalleryResponseDto.java
@@ -9,5 +9,7 @@ import java.time.LocalDateTime;
 @Builder
 public class GalleryResponseDto {
     private Long galleryId;
+    private String title;
+    private String content;
     private LocalDateTime createdAt;
 }

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/gallery/dto/GalleryResponseDto.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/gallery/dto/GalleryResponseDto.java
@@ -1,0 +1,13 @@
+package com.codestates.mainproject.oneyearfourcut.domain.gallery.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class GalleryResponseDto {
+    private Long galleryId;
+    private LocalDateTime createdAt;
+}

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/member/controller/MemberController.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/member/controller/MemberController.java
@@ -1,0 +1,26 @@
+package com.codestates.mainproject.oneyearfourcut.domain.member.controller;
+
+import com.codestates.mainproject.oneyearfourcut.domain.member.dto.MemberRequestDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/members")
+public class MemberController {
+    //회원 등록
+    @PostMapping
+    public ResponseEntity postMember(@RequestBody MemberRequestDto memberRequestDto) {
+        //Oauth 2.0 카카오 회원가입이면 MemberRequestDto로 받아오는 형식은 아닐 것 같은데, 일단 일반적인 회원가입처럼 구현
+
+        return new ResponseEntity(HttpStatus.CREATED);
+    }
+
+    //회원 탈퇴
+    @DeleteMapping("/me")
+    public ResponseEntity deleteMember() {
+        //jwt를 통해 memberId 알아내서 삭제 처리
+        return new ResponseEntity(HttpStatus.NO_CONTENT);
+    }
+
+}

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/member/dto/MemberRequestDto.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/member/dto/MemberRequestDto.java
@@ -1,0 +1,9 @@
+package com.codestates.mainproject.oneyearfourcut.domain.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MemberRequestDto {    //Oauth2.0 카카오 회원가입으로 변경시 없어질 듯
+    private String email;
+    private String nickname;
+}

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/vote/controller/VoteController.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/vote/controller/VoteController.java
@@ -1,0 +1,21 @@
+package com.codestates.mainproject.oneyearfourcut.domain.vote.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class VoteController {
+    //좋아요 누르기
+    @PostMapping("/galleries/{gallery-id}/artworks/{artwork-id}/vote")
+    public ResponseEntity postVote(@PathVariable("gallery-id") Long galleryId,
+                                   @PathVariable("artwork-id") Long artworkId) {
+
+        //jwt로 로그인 회원id를 가져온다
+        //memberId와 artworkId로 해당 좋아요가 존재하는지 체크, 있으면 삭제, 없으면 등록
+
+        return new ResponseEntity(HttpStatus.OK);
+    }
+}

--- a/server/oneyearfourcut/src/main/resources/db/data.sql
+++ b/server/oneyearfourcut/src/main/resources/db/data.sql
@@ -1,4 +1,6 @@
 INSERT INTO MEMBER (nickname, email, created_at, last_modified_at) VALUES
-('name1', 'test1@gmail.com', '2022-10-14 17:13:10', '2022-10-14 17:13:10'),
-('name2', 'test2@gmail.com', '2022-10-14 17:13:10', '2022-10-14 17:13:10'),
-('name3', 'test3@gmail.com', '2022-10-14 17:13:10', '2022-10-14 17:13:10');
+('galleryPerson', 'test1@gmail.com', '2022-11-16T23:41:57.764644', '2022-11-16T23:41:57.764644'),
+('artworkPerson', 'test2@gmail.com', '2022-11-16T23:41:57.764644', '2022-11-16T23:41:57.764644'),
+('commentPerson', 'test3@gmail.com', '2022-11-16T23:41:57.764644', '2022-11-16T23:41:57.764644'),
+('replyPerson', 'test4@gmail.com', '2022-11-16T23:41:57.764644', '2022-11-16T23:41:57.764644'),
+('votePerson', 'test5@gmail.com', '2022-11-16T23:41:57.764644', '2022-11-16T23:41:57.764644');

--- a/server/oneyearfourcut/src/main/resources/db/data.sql
+++ b/server/oneyearfourcut/src/main/resources/db/data.sql
@@ -1,4 +1,4 @@
-INSERT INTO MEMBER (member_id, nickname, email, created_at, last_modified_at) VALUES
-('1', 'name1', 'test1@gmail.com', '2022-10-14 17:13:10', '2022-10-14 17:13:10'),
-('2', 'name2', 'test2@gmail.com', '2022-10-14 17:13:10', '2022-10-14 17:13:10'),
-('3', 'name3', 'test3@gmail.com', '2022-10-14 17:13:10', '2022-10-14 17:13:10');
+INSERT INTO MEMBER (nickname, email, created_at, last_modified_at) VALUES
+('name1', 'test1@gmail.com', '2022-10-14 17:13:10', '2022-10-14 17:13:10'),
+('name2', 'test2@gmail.com', '2022-10-14 17:13:10', '2022-10-14 17:13:10'),
+('name3', 'test3@gmail.com', '2022-10-14 17:13:10', '2022-10-14 17:13:10');


### PR DESCRIPTION
- api명세서에 맞게 회원, 전시, 작품좋아요에서 mock데이터를 반환하는 controller를 구현했습니다.
- 관련 dto들을 만들었습니다.
- data.sql에 id값을 직접 넣으면 실제로 jpa를 통해 객체를 db에 저장하려할때 오류가 나서 member_id를 제거했습니다.