### PR TITLE
Feat/fe 84 업로드 페이지 기능 구현

### DIFF
--- a/client/src/UploadPicture/api.ts
+++ b/client/src/UploadPicture/api.ts
@@ -1,8 +1,32 @@
 import { jsonInstance, formdataInstance } from 'shared/utils/axios';
 import img from 'UploadPicture/1.jpg';
 
-const api = {
-  postImageAndContent: async (title: string, content: string) => {
+const apis = {
+  postImageAndContent: async (img: File, title: string, content: string, galleryId:number) => {
+    
+    const formdata = new FormData();
+    formdata.append('img', img);
+    formdata.append('title', title);
+    formdata.append('content', content);
+
+    return await formdataInstance.post(`/galleries/${galleryId}/artworks`, formdata);
+  },
+
+  getTest: async () => {
+    const data = await jsonInstance.get('/galleries/1/artworks');
+      console.log(data);
+      return data;
+    },
+  
+};
+
+export default apis;
+
+/*
+
+추후 지울 예정
+
+postImageAndContent: async (title: string, content: string) => {
     let blob = new Blob([new ArrayBuffer(img)], { type: 'image/jpg' });
 
     let reader = new FileReader();
@@ -33,16 +57,6 @@ const api = {
     const data = await formdataInstance.post('/galleries/1/artworks', formdata);
     console.log(data);
     return data;
-  },
-
-  getTest: async () => {
-    const data = await jsonInstance.get('/galleries/1/artworks');
-      console.log(data);
-      return data;
-    },
-  
-};
-
-export default api;
-
 // let blob = new Blob([new ArrayBuffer(img)], { type: "image/jpg" });
+
+*/

--- a/client/src/UploadPicture/api.ts
+++ b/client/src/UploadPicture/api.ts
@@ -1,62 +1,16 @@
-import { jsonInstance, formdataInstance } from 'shared/utils/axios';
-import img from 'UploadPicture/1.jpg';
+import { formdataInstance } from 'shared/utils/axios';
+import type { FormData } from './types';
 
 const apis = {
-  postImageAndContent: async (img: File, title: string, content: string, galleryId:number) => {
+  postImageAndContent: async (data : FormData) => {
     
     const formdata = new FormData();
-    formdata.append('img', img);
-    formdata.append('title', title);
-    formdata.append('content', content);
+    formdata.append('img', data.img);
+    formdata.append('title', data.title);
+    formdata.append('content', data.content);
 
-    return await formdataInstance.post(`/galleries/${galleryId}/artworks`, formdata);
+    return await formdataInstance.post(`/galleries/${data.galleryId}/artworks`, formdata);
   },
-
-  getTest: async () => {
-    const data = await jsonInstance.get('/galleries/1/artworks');
-      console.log(data);
-      return data;
-    },
-  
 };
 
 export default apis;
-
-/*
-
-추후 지울 예정
-
-postImageAndContent: async (title: string, content: string) => {
-    let blob = new Blob([new ArrayBuffer(img)], { type: 'image/jpg' });
-
-    let reader = new FileReader();
-    reader.readAsDataURL(blob); // 1. 파일을 읽어 버퍼에 저장합니다.
-    // 파일 상태 업데이트
-    reader.onloadend = () => {
-      // 2. 읽기가 완료되면 아래코드가 실행됩니다.
-      const base64 = reader.result;
-      if (base64) {
-        //  images.push(base64.toString())
-        var base64Sub = base64.toString();
-
-        const setImgBase64 = base64Sub;
-          console.log(setImgBase64);
-          return setImgBase64
-      }
-    };
-
-    console.log(reader);
-
-    const formdata = new FormData();
-    // formdata.append('img', blob2);
-    formdata.append('title', title);
-    formdata.append('content', content);
-
-    console.log(formdata);
-
-    const data = await formdataInstance.post('/galleries/1/artworks', formdata);
-    console.log(data);
-    return data;
-// let blob = new Blob([new ArrayBuffer(img)], { type: "image/jpg" });
-
-*/

--- a/client/src/UploadPicture/components/Container.tsx
+++ b/client/src/UploadPicture/components/Container.tsx
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 import { rem } from 'polished';
 
-const DefualtContainer = styled.div`
+const DefualtContainer = styled.form`
   width: ${rem(428)};
   height: 95vh;
   display: flex;
   flex-direction: column;
-  background-color: ${({theme}) => theme.colors.black_007};
+  background-color: ${({ theme }) => theme.colors.black_007};
 `;
 
 const UploadPictureContainer = styled.div`
@@ -15,44 +15,68 @@ const UploadPictureContainer = styled.div`
   margin-top: ${rem(38)};
   padding: 0 ${rem(40)} 0 ${rem(40)};
   position: relative;
-
   h2 {
     margin-bottom: ${rem(20)};
   }
-  .UploadSvg {
+  .DeleteImg {
     font-size: ${rem(12)};
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    position: absolute;
-    top: 45%;
-    left: 30%;
-  }
-  .DeleteImg{
-    font-size: ${rem(12)};
-    margin-left: ${rem(310)}
+    margin-left: ${rem(310)};
   }
 `;
+
+//유저가 올린 이미지
+const UploadUserImgBox = styled.div`
+  width: ${rem(322)};
+  height: ${rem(322)};
+  font-size: ${rem(12)};
+  position: absolute;
+  top: 17%;
+  left: 12%;
+  label {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center; 
+    justify-content: center;
+  }
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: scale-down;
+  }
+  input {
+    display: none;
+  }
+`;
+
 const InputContainer = styled.div`
   width: ${rem(428)};
   height: ${rem(223)};
   margin-top: ${rem(53)};
 `;
 const UploadBtnContainer = styled.div`
-    width: ${rem(428)};
+  width: ${rem(428)};
+  height: ${rem(40)};
+  margin-top: ${rem(59)};
+  margin-bottom: ${rem(65)};
+  button {
+    width: ${rem(100)};
     height: ${rem(40)};
-    margin-top: ${rem(59)};
-    margin-bottom: ${rem(65)};
-    button{
-        width: ${rem(100)};
-        height: ${rem(40)};
-        background-color: ${({ theme }) => theme.colors.green_002};
-        border-radius: ${rem(5)};
-        border: none;
-        color: white;
-        font-size: ${rem(16)};
-        margin-left: ${rem(294)};
-    }
+    background-color: ${({ theme }) => theme.colors.green_002};
+    border-radius: ${rem(5)};
+    border: none;
+    color: white;
+    font-size: ${rem(16)};
+    margin-left: ${rem(294)};
+  }
+`;
+const UploadImgline = styled.img`
+  width: ${rem(346)};
+  height: ${rem(346)};
+  background-image: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' rx='22' ry='22' stroke='%23316232FF' stroke-width='6' stroke-dasharray='5%2c 15' stroke-dashoffset='22' stroke-linecap='square'/%3e%3c/svg%3e");
+  border-radius: 22px;
+  border: hidden;
 `;
 
 export {
@@ -60,4 +84,6 @@ export {
   UploadPictureContainer,
   InputContainer,
   UploadBtnContainer,
+  UploadUserImgBox,
+  UploadImgline,
 };

--- a/client/src/UploadPicture/components/Input.tsx
+++ b/client/src/UploadPicture/components/Input.tsx
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 import { rem } from 'polished';
 import * as S from './SvgComponents';
+import { UploadStore } from 'store/store';
 
-const InputBox = styled.div`
+const InputBox = styled.div<{ data: string }>`
   display: flex;
   flex-direction: column;
   padding: 0 ${rem(43)} 0 ${rem(43)};
@@ -18,7 +19,7 @@ const InputBox = styled.div`
     margin-top: ${rem(3)};
   }
   input:focus {
-    outline-color: ${({ theme }) => theme.colors.green_002};
+    outline-color: ${({ theme,data }) => data ? theme.colors.green_002 : theme.colors.red_003};
   }
 
   .SVG {
@@ -36,24 +37,25 @@ const InputBox = styled.div`
     resize: none;
   }
   textarea:focus {
-    outline-color: ${({ theme }) => theme.colors.green_002};
+    outline-color: ${({ theme,data }) => data ? theme.colors.green_002 : theme.colors.red_003};
   }
 `;
 
 
 
 const Input = () => {
+  const { UploadData, setData } = UploadStore();
+
   return (
     <>
-      <InputBox>
-        <label>작품 제목</label>
-        <input></input>
-        <S.EmptySVG className='SVG'></S.EmptySVG>
-        {/* 경고시 S.CautionSVG 나타나야함 */}
+      <InputBox data={UploadData.title}>
+        <label htmlFor='title'>작품 제목</label>
+        <input id='title' value={UploadData.title} onChange={(e: React.ChangeEvent<HTMLInputElement>)=> setData("title",e.target.value)}></input>
+        {/* <S.EmptySVG className='SVG'/> */}
       </InputBox>
-      <InputBox>
-        <label>작품 설명</label>
-        <textarea maxLength={90}></textarea>
+      <InputBox data={UploadData.content}>
+        <label htmlFor='content' >작품 설명</label>
+        <textarea id='content' maxLength={90} value={UploadData.content} onChange={(e: React.ChangeEvent<HTMLTextAreaElement>)=> setData("content",e.target.value)}></textarea>
       </InputBox>
     </>
   );

--- a/client/src/UploadPicture/components/Input.tsx
+++ b/client/src/UploadPicture/components/Input.tsx
@@ -19,7 +19,8 @@ const InputBox = styled.div<{ data: string }>`
     margin-top: ${rem(3)};
   }
   input:focus {
-    outline-color: ${({ theme,data }) => data ? theme.colors.green_002 : theme.colors.red_003};
+    outline-color: ${({ theme, data }) =>
+      data ? theme.colors.green_002 : theme.colors.red_003};
   }
 
   .SVG {
@@ -37,11 +38,10 @@ const InputBox = styled.div<{ data: string }>`
     resize: none;
   }
   textarea:focus {
-    outline-color: ${({ theme,data }) => data ? theme.colors.green_002 : theme.colors.red_003};
+    outline-color: ${({ theme, data }) =>
+      data ? theme.colors.green_002 : theme.colors.red_003};
   }
 `;
-
-
 
 const Input = () => {
   const { UploadData, setData } = UploadStore();
@@ -50,12 +50,24 @@ const Input = () => {
     <>
       <InputBox data={UploadData.title}>
         <label htmlFor='title'>작품 제목</label>
-        <input id='title' value={UploadData.title} onChange={(e: React.ChangeEvent<HTMLInputElement>)=> setData("title",e.target.value)}></input>
-        {/* <S.EmptySVG className='SVG'/> */}
+        <input
+          id='title'
+          value={UploadData.title}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setData('title', e.target.value)
+          }
+        ></input>
       </InputBox>
       <InputBox data={UploadData.content}>
-        <label htmlFor='content' >작품 설명</label>
-        <textarea id='content' maxLength={90} value={UploadData.content} onChange={(e: React.ChangeEvent<HTMLTextAreaElement>)=> setData("content",e.target.value)}></textarea>
+        <label htmlFor='content'>작품 설명</label>
+        <textarea
+          id='content'
+          maxLength={90}
+          value={UploadData.content}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+            setData('content', e.target.value)
+          }
+        ></textarea>
       </InputBox>
     </>
   );

--- a/client/src/UploadPicture/components/SvgComponents.tsx
+++ b/client/src/UploadPicture/components/SvgComponents.tsx
@@ -77,6 +77,7 @@ const UploadSvg = () => {
       viewBox='0 0 101 101'
       fill='none'
       xmlns='http://www.w3.org/2000/svg'
+      className='UploadSvg'
     >
       <g opacity='0.4'>
         <path

--- a/client/src/UploadPicture/components/Upload.tsx
+++ b/client/src/UploadPicture/components/Upload.tsx
@@ -7,7 +7,7 @@ const Upload = () => {
     <C.UploadPictureContainer>
       <h2>작품 등록하기</h2>
       <C.UploadImgline />
-      <B.UploadUserImgBox/>
+      <B.UploadUserImgBox />
       <label className='DeleteImg' onClick={removeData}>
         삭제
       </label>

--- a/client/src/UploadPicture/components/Upload.tsx
+++ b/client/src/UploadPicture/components/Upload.tsx
@@ -1,29 +1,16 @@
-import styled from 'styled-components';
-import { rem } from 'polished';
 import * as C from './Container';
-import { UploadSvg } from './SvgComponents';
-const UploadImg = styled.img`
-  width: ${rem(346)};
-  height: ${rem(346)};
-  padding: 10px;
-  background-image: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' rx='22' ry='22' stroke='%23316232FF' stroke-width='4' stroke-dasharray='5%2c 15' stroke-dashoffset='22' stroke-linecap='square'/%3e%3c/svg%3e");
-  border-radius: 22px;
-  display: inline-block;
-  content: '';
-`;
-
-
-
+import * as B from './UploadImg';
+import { UploadStore } from 'store/store';
 const Upload = () => {
+  const { removeData } = UploadStore();
   return (
     <C.UploadPictureContainer>
       <h2>작품 등록하기</h2>
-      <UploadImg></UploadImg>
-      <div className='UploadSvg'>
-        <UploadSvg></UploadSvg>
-        <label>올해 1년을 장식할 작품을 올려주세요</label>
-      </div>
-      <label className='DeleteImg'>삭제</label>
+      <C.UploadImgline />
+      <B.UploadUserImgBox/>
+      <label className='DeleteImg' onClick={removeData}>
+        삭제
+      </label>
     </C.UploadPictureContainer>
   );
 };

--- a/client/src/UploadPicture/components/UploadImg.tsx
+++ b/client/src/UploadPicture/components/UploadImg.tsx
@@ -1,8 +1,8 @@
 import * as B from './Container';
 import { UploadSvg } from './SvgComponents';
-import { ToastStore, UploadStore } from 'store/store';
+import { UploadStore } from 'store/store';
 import { useRef } from 'react';
-
+import useToast from 'shared/components/Toast/hooks/useToast';
 interface EmptyImg {
   setUploadImg: (file: File | undefined) => void;
 }
@@ -11,11 +11,6 @@ interface UserImg extends EmptyImg {
   uploadImg: File | undefined;
 }
 const ALLOW_FILE_EXTENSION = 'jpg, jpeg, png, heic';
-
-const obj = {
-  time: 3000,
-  content: ['아래의 확장자만 사용이 가능합니다 확장자를 확인해주세요', `(${ALLOW_FILE_EXTENSION})`],
-};
 
 const uploadHelper = (name: string) => {
   const result = name.split('.').map((el) => el.toLowerCase());
@@ -28,22 +23,25 @@ const uploadHelper = (name: string) => {
 };
 
 const UploadUserImgBox = () => {
-  const { addToast, removeToast } = ToastStore();
   const { UploadData, setData } = UploadStore();
+  const { setToast } = useToast();
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleOnchange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files && uploadHelper(event.target.files[0].name))
       // setUploadImg(event.target.files[0]);
-      setData('img', event.target.files[0])
+      setData('img', event.target.files[0]);
     else {
-      addToast(obj);
-      setTimeout(() => removeToast(), 3000);
+      console.log("hi");
+      setToast(3000, [
+        '아래의 확장자만 사용이 가능합니다 확장자를 확인해주세요',
+        ALLOW_FILE_EXTENSION,
+      ]);
     }
   };
   if (UploadData.img === undefined && inputRef.current)
-    inputRef.current.value= "";
-  
+    inputRef.current.value = '';
+
   return (
     <B.UploadUserImgBox>
       <label htmlFor='input-file'>
@@ -56,7 +54,12 @@ const UploadUserImgBox = () => {
           </>
         )}
       </label>
-      <input type='file' id='input-file' ref={inputRef} onChange={handleOnchange} />
+      <input
+        type='file'
+        id='input-file'
+        ref={inputRef}
+        onChange={handleOnchange}
+      />
     </B.UploadUserImgBox>
   );
 };

--- a/client/src/UploadPicture/components/UploadImg.tsx
+++ b/client/src/UploadPicture/components/UploadImg.tsx
@@ -3,13 +3,7 @@ import { UploadSvg } from './SvgComponents';
 import { UploadStore } from 'store/store';
 import { useRef } from 'react';
 import useToast from 'shared/components/Toast/hooks/useToast';
-interface EmptyImg {
-  setUploadImg: (file: File | undefined) => void;
-}
 
-interface UserImg extends EmptyImg {
-  uploadImg: File | undefined;
-}
 const ALLOW_FILE_EXTENSION = 'jpg, jpeg, png, heic';
 
 const uploadHelper = (name: string) => {
@@ -29,18 +23,17 @@ const UploadUserImgBox = () => {
 
   const handleOnchange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files && uploadHelper(event.target.files[0].name))
-      // setUploadImg(event.target.files[0]);
       setData('img', event.target.files[0]);
     else {
-      console.log("hi");
+      if (UploadData.img === undefined || inputRef.current)
+        inputRef.current!.value = ''; //onChange 이벤트 활성화를 위한 초기화
+
       setToast(3000, [
         '아래의 확장자만 사용이 가능합니다 확장자를 확인해주세요',
         ALLOW_FILE_EXTENSION,
       ]);
     }
   };
-  if (UploadData.img === undefined && inputRef.current)
-    inputRef.current.value = '';
 
   return (
     <B.UploadUserImgBox>

--- a/client/src/UploadPicture/components/UploadImg.tsx
+++ b/client/src/UploadPicture/components/UploadImg.tsx
@@ -1,0 +1,64 @@
+import * as B from './Container';
+import { UploadSvg } from './SvgComponents';
+import { ToastStore, UploadStore } from 'store/store';
+import { useRef } from 'react';
+
+interface EmptyImg {
+  setUploadImg: (file: File | undefined) => void;
+}
+
+interface UserImg extends EmptyImg {
+  uploadImg: File | undefined;
+}
+const ALLOW_FILE_EXTENSION = 'jpg, jpeg, png, heic';
+
+const obj = {
+  time: 3000,
+  content: ['아래의 확장자만 사용이 가능합니다 확장자를 확인해주세요', `(${ALLOW_FILE_EXTENSION})`],
+};
+
+const uploadHelper = (name: string) => {
+  const result = name.split('.').map((el) => el.toLowerCase());
+
+  if (result[1] && ALLOW_FILE_EXTENSION.indexOf(result[1]) > -1) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
+const UploadUserImgBox = () => {
+  const { addToast, removeToast } = ToastStore();
+  const { UploadData, setData } = UploadStore();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleOnchange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files && uploadHelper(event.target.files[0].name))
+      // setUploadImg(event.target.files[0]);
+      setData('img', event.target.files[0])
+    else {
+      addToast(obj);
+      setTimeout(() => removeToast(), 3000);
+    }
+  };
+  if (UploadData.img === undefined && inputRef.current)
+    inputRef.current.value= "";
+  
+  return (
+    <B.UploadUserImgBox>
+      <label htmlFor='input-file'>
+        {UploadData.img ? (
+          <img src={URL.createObjectURL(UploadData.img)} alt='' />
+        ) : (
+          <>
+            <UploadSvg />
+            올해 1년을 장식할 작품을 올려주세요
+          </>
+        )}
+      </label>
+      <input type='file' id='input-file' ref={inputRef} onChange={handleOnchange} />
+    </B.UploadUserImgBox>
+  );
+};
+
+export { UploadUserImgBox };

--- a/client/src/UploadPicture/hook/useUpload.tsx
+++ b/client/src/UploadPicture/hook/useUpload.tsx
@@ -1,18 +1,30 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import apis from '../api'
+import { useMutation } from '@tanstack/react-query';
+import apis from '../api';
+import { ModalStore } from 'store/store';
+import useToast from 'shared/components/Toast/hooks/useToast';
+import { FormData } from '../types';
 
-const useUpload = (img: File, title: string, content: string, galleryId:number) => {
-    const queryClient = useQueryClient();
+const useUpload = () => {
+  const { closeModal } = ModalStore();
+  const { setToast } = useToast();
 
-    // const { data } = useMutation(['useUpload'], apis.postImageAndContent(img, title, content, galleryId));
-    const { data, error, status } = useMutation(['useUpload'], () => apis.postImageAndContent(img, title, content, galleryId), {
-        onMutate() {
-            return true;
-        },
-        
-    });
-    
+  const { mutate } = useMutation(
+    ['useUpload'],
+    (formData: FormData) => apis.postImageAndContent(formData),
+    {
+      onMutate() {
+        closeModal('AlertModal');
+      },
+      onSuccess() {
+        setToast(3000, ['작품이 등록되었습니다.', '내 전시관도 만들어보기']);
+      },
+      onError() {
+        alert('작품 업로드 오류');
+      },
+    },
+  );
 
-}
+  return { mutate };
+};
 
 export default useUpload;

--- a/client/src/UploadPicture/hook/useUpload.tsx
+++ b/client/src/UploadPicture/hook/useUpload.tsx
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import apis from '../api'
+
+const useUpload = (img: File, title: string, content: string, galleryId:number) => {
+    const queryClient = useQueryClient();
+
+    // const { data } = useMutation(['useUpload'], apis.postImageAndContent(img, title, content, galleryId));
+    const { data, error, status } = useMutation(['useUpload'], () => apis.postImageAndContent(img, title, content, galleryId), {
+        onMutate() {
+            return true;
+        },
+        
+    });
+    
+
+}
+
+export default useUpload;

--- a/client/src/UploadPicture/index.tsx
+++ b/client/src/UploadPicture/index.tsx
@@ -1,21 +1,22 @@
 import * as C from './components/Container';
 import Upload from './components/Upload';
 import { Input } from './components/Input';
-import { ModalStore, UploadStore, ToastStore } from 'store/store';
+import { ModalStore, UploadStore } from 'store/store';
 import { Alert } from 'shared/components/Modal/components/Alert';
 import ModalBackdrop from 'shared/components/Modal/components/ModalBackdrop';
 import { useRef } from 'react';
 import { formdataInstance } from 'shared/utils/axios';
+import useToast from 'shared/components/Toast/hooks/useToast';
 
 const UploadPicture = () => {
   const { target, openModal, closeModal } = ModalStore();
-  const { addToast, removeToast } = ToastStore();
   const { UploadData } = UploadStore();
+  const { setToast } = useToast();
   const formRef = useRef<HTMLFormElement>(null);
-  
+
   const onClick = () => {
     //여기에 progressBtn을 눌렀을때 필요한 로직 작성
-    closeModal("AlertModal");
+    closeModal('AlertModal');
   };
 
   const data = {
@@ -26,16 +27,17 @@ const UploadPicture = () => {
   };
 
   const handlePostbtn = (event: React.FormEvent<HTMLFormElement>) => {
-    // const handlePostbtn = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (Object.values(UploadData).filter(el => !el).length > 0) {
-      const obj = {
-        time: 3000, //ms
-        content: ['입력하지 않은곳이 있는지 확인해주세요', '제목과 설명은 30자 이하여야합니다.'], //위,아래에 들어갈 원하는 내용 작성
-      };
-      addToast(obj); //ToastStore에 Toast 추가
-      setTimeout(() => removeToast(), 3000); //ToastStroe에서 만든 Toast요소제거
+    if (
+      Object.values(UploadData).filter((el) => !el).length > 0 ||
+      UploadData.content.length > 30 ||
+      UploadData.title.length > 15
+    ) {
+      setToast(3000, [
+        '입력하지 않은곳이 있는지 확인해주세요',
+        '제목은 15글자, 설명은 30글자 이하여야합니다.',
+      ]);
       return;
     }
 
@@ -44,17 +46,16 @@ const UploadPicture = () => {
     data.append('title', UploadData.title);
     data.append('content', UploadData.content);
 
-    // const data2 = new FormData(formRef.current!)
+    // const data2 = new FormData(formRef.current!) 데이터 어떻게 들어가는지 확인해보기
     formdataInstance.post('/', data);
-
-  }
+  };
 
   return (
     <>
       <C.DefualtContainer onSubmit={handlePostbtn} ref={formRef}>
-        <Upload/>
+        <Upload />
         <C.InputContainer>
-          <Input/>
+          <Input />
         </C.InputContainer>
         <C.UploadBtnContainer>
           <button type='submit'>등록하기</button>
@@ -63,7 +64,7 @@ const UploadPicture = () => {
       {/* 모달 생성부분 */}
       {target.AlertModal ? (
         <ModalBackdrop>
-          <Alert data={data}/>
+          <Alert data={data} />
         </ModalBackdrop>
       ) : null}
     </>

--- a/client/src/UploadPicture/index.tsx
+++ b/client/src/UploadPicture/index.tsx
@@ -1,11 +1,18 @@
 import * as C from './components/Container';
 import Upload from './components/Upload';
 import { Input } from './components/Input';
-import { ModalStore } from 'store/store';
+import { ModalStore, UploadStore, ToastStore } from 'store/store';
 import { Alert } from 'shared/components/Modal/components/Alert';
 import ModalBackdrop from 'shared/components/Modal/components/ModalBackdrop';
+import { useRef } from 'react';
+import { formdataInstance } from 'shared/utils/axios';
+
 const UploadPicture = () => {
   const { target, openModal, closeModal } = ModalStore();
+  const { addToast, removeToast } = ToastStore();
+  const { UploadData } = UploadStore();
+  const formRef = useRef<HTMLFormElement>(null);
+  
   const onClick = () => {
     //여기에 progressBtn을 눌렀을때 필요한 로직 작성
     closeModal("AlertModal");
@@ -18,15 +25,39 @@ const UploadPicture = () => {
     onClick: onClick,
   };
 
+  const handlePostbtn = (event: React.FormEvent<HTMLFormElement>) => {
+    // const handlePostbtn = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (Object.values(UploadData).filter(el => !el).length > 0) {
+      const obj = {
+        time: 3000, //ms
+        content: ['입력하지 않은곳이 있는지 확인해주세요', '제목과 설명은 30자 이하여야합니다.'], //위,아래에 들어갈 원하는 내용 작성
+      };
+      addToast(obj); //ToastStore에 Toast 추가
+      setTimeout(() => removeToast(), 3000); //ToastStroe에서 만든 Toast요소제거
+      return;
+    }
+
+    const data = new FormData();
+    data.append('img', UploadData.img!);
+    data.append('title', UploadData.title);
+    data.append('content', UploadData.content);
+
+    // const data2 = new FormData(formRef.current!)
+    formdataInstance.post('/', data);
+
+  }
+
   return (
     <>
-      <C.DefualtContainer>
+      <C.DefualtContainer onSubmit={handlePostbtn} ref={formRef}>
         <Upload/>
         <C.InputContainer>
           <Input/>
         </C.InputContainer>
         <C.UploadBtnContainer>
-          <button onClick={()=>openModal("AlertModal")}>등록하기</button>
+          <button type='submit'>등록하기</button>
         </C.UploadBtnContainer>
       </C.DefualtContainer>
       {/* 모달 생성부분 */}

--- a/client/src/UploadPicture/index.tsx
+++ b/client/src/UploadPicture/index.tsx
@@ -1,29 +1,32 @@
 import * as C from './components/Container';
+import ModalBackdrop from 'shared/components/Modal/components/ModalBackdrop';
+import useToast from 'shared/components/Toast/hooks/useToast';
+import useUpload from './hook/useUpload';
 import Upload from './components/Upload';
 import { Input } from './components/Input';
 import { ModalStore, UploadStore } from 'store/store';
 import { Alert } from 'shared/components/Modal/components/Alert';
-import ModalBackdrop from 'shared/components/Modal/components/ModalBackdrop';
 import { useRef } from 'react';
-import useToast from 'shared/components/Toast/hooks/useToast';
 import { UploadAlert } from '../../src/shared/components/Modal/AlertData';
+import { useParams } from 'react-router-dom';
 
 const UploadPicture = () => {
-  const { target, openModal, closeModal } = ModalStore();
+  const { target, openModal } = ModalStore();
   const { UploadData } = UploadStore();
   const { setToast } = useToast();
+  const { galleryId } = useParams();
+  const { mutate } = useUpload();
   const formRef = useRef<HTMLFormElement>(null);
 
-  const onClick = () => {
-    //여기에 progressBtn을 눌렀을때 필요한 로직 작성
-    closeModal('AlertModal');
-  };
+  const handleProgressBtn = () => {
+    const upLoadData = {
+      img: UploadData.img!,
+      title: UploadData.title,
+      content: UploadData.content,
+      galleryId: galleryId!,
+    };
 
-  const data = {
-    title: '작품을 등록하시겠습니까?',
-    content: '등록하기',
-    color: 'green',
-    onClick: onClick,
+    mutate(upLoadData);
   };
 
   const handlePostbtn = (event: React.FormEvent<HTMLFormElement>) => {
@@ -39,9 +42,8 @@ const UploadPicture = () => {
         '제목은 15글자, 설명은 30글자 이하여야합니다.',
       ]);
       return;
-    }
-    else {
-      openModal("AlertModal")
+    } else {
+      openModal('AlertModal');
     }
   };
   // const data2 = new FormData(formRef.current!) 데이터 어떻게 들어가는지 확인해보기
@@ -60,7 +62,7 @@ const UploadPicture = () => {
       {/* 모달 생성부분 */}
       {target.AlertModal ? (
         <ModalBackdrop>
-          <Alert data={UploadAlert(onClick)} />
+          <Alert data={UploadAlert(handleProgressBtn)} />
         </ModalBackdrop>
       ) : null}
     </>

--- a/client/src/UploadPicture/index.tsx
+++ b/client/src/UploadPicture/index.tsx
@@ -5,8 +5,8 @@ import { ModalStore, UploadStore } from 'store/store';
 import { Alert } from 'shared/components/Modal/components/Alert';
 import ModalBackdrop from 'shared/components/Modal/components/ModalBackdrop';
 import { useRef } from 'react';
-import { formdataInstance } from 'shared/utils/axios';
 import useToast from 'shared/components/Toast/hooks/useToast';
+import { UploadAlert } from '../../src/shared/components/Modal/AlertData';
 
 const UploadPicture = () => {
   const { target, openModal, closeModal } = ModalStore();
@@ -40,15 +40,11 @@ const UploadPicture = () => {
       ]);
       return;
     }
-
-    const data = new FormData();
-    data.append('img', UploadData.img!);
-    data.append('title', UploadData.title);
-    data.append('content', UploadData.content);
-
-    // const data2 = new FormData(formRef.current!) 데이터 어떻게 들어가는지 확인해보기
-    formdataInstance.post('/', data);
+    else {
+      openModal("AlertModal")
+    }
   };
+  // const data2 = new FormData(formRef.current!) 데이터 어떻게 들어가는지 확인해보기
 
   return (
     <>
@@ -64,7 +60,7 @@ const UploadPicture = () => {
       {/* 모달 생성부분 */}
       {target.AlertModal ? (
         <ModalBackdrop>
-          <Alert data={data} />
+          <Alert data={UploadAlert(onClick)} />
         </ModalBackdrop>
       ) : null}
     </>

--- a/client/src/UploadPicture/types.ts
+++ b/client/src/UploadPicture/types.ts
@@ -1,0 +1,8 @@
+interface FormData {
+  img: File;
+  title: string;
+  content: string;
+  galleryId: string;
+}
+
+export type { FormData };

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -5,16 +5,31 @@ import App from './App';
 import GlobalStyle from './shared/styled/GlobalStyle';
 import { ThemeProvider } from 'styled-components';
 import { theme } from './shared/styled/Theme';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
 );
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 0,
+      suspense: true,
+      refetchOnWindowFocus: false,
+    }
+  }
+});
+
 root.render(
   <React.StrictMode>
-    <ThemeProvider theme={theme}>
-      <GlobalStyle />
-      <App />
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ReactQueryDevtools initialIsOpen={true}/>
+      <ThemeProvider theme={theme}>
+        <GlobalStyle />
+        <App />
+        </ThemeProvider>
+    </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -15,9 +15,8 @@ const root = ReactDOM.createRoot(
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      retry: 0,
+      retry: 0,   //디버깅용도 추후에 삭제
       suspense: true,
-      refetchOnWindowFocus: false,
     }
   }
 });

--- a/client/src/shared/components/Modal/AlertData.ts
+++ b/client/src/shared/components/Modal/AlertData.ts
@@ -3,6 +3,7 @@ export const UploadAlert = (onClick : ()=>void)=>{
         title: '작품을 등록하시겠습니까?',
         content: '등록하기',
         color: 'green',
+        target: 'AlertModal',
         onClick: onClick,
     }
     return data;
@@ -13,6 +14,7 @@ export const DeleteAlert = (onClick : ()=>void)=>{
         title: '작품을 삭제하시겠습니까?',
         content: '삭제하기',
         color: 'red',
+        target: 'DeleteModal',
         onClick: onClick,
     }
     return data;

--- a/client/src/shared/components/Modal/AlertData.ts
+++ b/client/src/shared/components/Modal/AlertData.ts
@@ -1,0 +1,19 @@
+export const UploadAlert = (onClick : ()=>void)=>{
+    const data = {
+        title: '작품을 등록하시겠습니까?',
+        content: '등록하기',
+        color: 'green',
+        onClick: onClick,
+    }
+    return data;
+};
+
+export const DeleteAlert = (onClick : ()=>void)=>{
+    const data = {
+        title: '작품을 삭제하시겠습니까?',
+        content: '삭제하기',
+        color: 'red',
+        onClick: onClick,
+    }
+    return data;
+};

--- a/client/src/shared/components/Modal/components/Alert.tsx
+++ b/client/src/shared/components/Modal/components/Alert.tsx
@@ -1,30 +1,25 @@
 import * as S from './SvgComponents';
 import { ModalStore } from 'store/store';
 import { ModalViewBox, ModalbtnBox } from './ModalContainer';
-import useToast from '../../Toast/hooks/useToast';
 
 interface Data {
   title: string;
   content: string;
   color: string;
+  target: string;
   onClick: () => void;
 }
 
 const Alert = ({ data }: { data: Data }) => {
   const { closeModal } = ModalStore();
-  const { setToast } = useToast();
-  const handleOnClick = () => {
-    closeModal('AlertModal');
-    setToast(3000, ['작품이 등록되었습니다.', '내 전시관도 만들어보기']);
-  };
 
   return (
     <ModalViewBox color={data.color}>
       <S.ApplySVG></S.ApplySVG>
       <h3>{data.title}</h3>
       <ModalbtnBox>
-        <button onClick={() => closeModal('AlertModal')}>취소</button>
-        <button className='Progressbtn' onClick={handleOnClick}>
+        <button onClick={() => closeModal(data.target)}>취소</button>
+        <button className='Progressbtn' onClick={data.onClick}>
           {data.content}{' '}
         </button>
       </ModalbtnBox>

--- a/client/src/shared/components/Modal/components/Alert.tsx
+++ b/client/src/shared/components/Modal/components/Alert.tsx
@@ -19,7 +19,6 @@ const Alert = ({ data }: { data: Data }) => {
     const obj = {
       time: 3000, //ms
       content: ['작품이 등록되었습니다.', '내 전시관도 만들어보기'], //위,아래에 들어갈 원하는 내용 작성
-      id: Math.random(), //key값을 위함. uuid를 써도됨
     };
     addToast(obj); //ToastStore에 Toast 추가
     setTimeout(() => removeToast(), 3000); //ToastStroe에서 만든 Toast요소제거

--- a/client/src/shared/components/Modal/components/Alert.tsx
+++ b/client/src/shared/components/Modal/components/Alert.tsx
@@ -1,6 +1,7 @@
 import * as S from './SvgComponents';
-import { ModalStore, ToastStore } from 'store/store';
+import { ModalStore } from 'store/store';
 import { ModalViewBox, ModalbtnBox } from './ModalContainer';
+import useToast from '../../Toast/hooks/useToast';
 
 interface Data {
   title: string;
@@ -11,17 +12,10 @@ interface Data {
 
 const Alert = ({ data }: { data: Data }) => {
   const { closeModal } = ModalStore();
-  const { addToast, removeToast } = ToastStore();
-
+  const { setToast } = useToast();
   const handleOnClick = () => {
     closeModal('AlertModal');
-
-    const obj = {
-      time: 3000, //ms
-      content: ['작품이 등록되었습니다.', '내 전시관도 만들어보기'], //위,아래에 들어갈 원하는 내용 작성
-    };
-    addToast(obj); //ToastStore에 Toast 추가
-    setTimeout(() => removeToast(), 3000); //ToastStroe에서 만든 Toast요소제거
+    setToast(3000, ['작품이 등록되었습니다.', '내 전시관도 만들어보기']);
   };
 
   return (

--- a/client/src/shared/components/Toast/components/ToastContainer.tsx
+++ b/client/src/shared/components/Toast/components/ToastContainer.tsx
@@ -28,7 +28,7 @@ const ToastBox = styled.div<{ time: number }>`
 
   .ToastContentBox {
     width: ${rem(350)};
-    margin: ${rem(10)} 0 ${rem(5)} 0;
+    margin: ${rem(15)} 0 ${rem(10)} 0;
     font-size: ${rem(12)};
     display: flex;
     align-items: center;

--- a/client/src/shared/components/Toast/components/ToastContainer.tsx
+++ b/client/src/shared/components/Toast/components/ToastContainer.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 import { rem } from 'polished';
 
-
 //toast 메세지들이 들어갈 공간
 const ToastRenderBox = styled.div`
   width: ${rem(400)};
@@ -15,7 +14,7 @@ const ToastRenderBox = styled.div`
 `;
 
 //실제 Toast 메세지
-const ToastBox = styled.div<{time:number}>`
+const ToastBox = styled.div<{ time: number }>`
   width: ${rem(395)};
   height: ${rem(64)};
   margin: ${rem(18)} ${rem(18)} 0 ${rem(18)};
@@ -24,17 +23,23 @@ const ToastBox = styled.div<{time:number}>`
   display: flex;
   flex-direction: column;
   align-items: center;
-  animation: ToastShow ${({time}) => time/1000}s linear forwards;
+  animation: ToastShow ${({ time }) => time / 1000}s linear forwards;
   background-color: white;
 
-  .ToastContent {
-    width: ${rem(250)};
+  .ToastContentBox {
+    width: ${rem(350)};
+    margin: ${rem(10)} 0 ${rem(5)} 0;
+    font-size: ${rem(12)};
     display: flex;
     align-items: center;
-    margin: ${rem(10)} 0 ${rem(5)} ${rem(100)};
+    justify-content: center;
 
-    label {
-      margin-right: ${rem(50)};
+    .ToastContent {
+      width: ${rem(340)};
+      text-align: center;
+
+    }
+    .OptionSVG {
     }
   }
   @keyframes ToastShow {
@@ -54,7 +59,7 @@ const ToastBox = styled.div<{time:number}>`
 `;
 
 //실제 Toast 메세지의 progress bar
-const ProgressBar = styled.div<{time:number}>`
+const ProgressBar = styled.div<{ time: number }>`
   width: ${rem(395)};
   height: ${rem(4)};
   background-color: ${({ theme }) => theme.colors.green_007};
@@ -78,9 +83,8 @@ const ProgressBar = styled.div<{time:number}>`
     width: 0;
     height: ${rem(4)};
     background-color: ${({ theme }) => theme.colors.green_006};
-    animation: progress ${({time}) => time/1000}s linear forwards;
+    animation: progress ${({ time }) => time / 1000}s linear forwards;
   }
 `;
-
 
 export { ToastRenderBox, ToastBox, ProgressBar };

--- a/client/src/shared/components/Toast/components/ToastMessage.tsx
+++ b/client/src/shared/components/Toast/components/ToastMessage.tsx
@@ -16,12 +16,12 @@ const ToastMessage = ({
     <>
       {show && (
         <T.ToastBox time={time}>
-          <div className='ToastContent'>
-            <label>
-              {content[0]} <br/>
+          <div className='ToastContentBox'>
+            <div className='ToastContent'>
+              {content[0]} <br />
               {content[1]}
-            </label>
-            <OptionSVG onClick={() => setShow(false)} />
+              </div>  
+          <OptionSVG onClick={() => setShow(false)} />
           </div>
           <T.ProgressBar className='ProgressBar' time={time}></T.ProgressBar>
         </T.ToastBox>

--- a/client/src/shared/components/Toast/components/ToastMessage.tsx
+++ b/client/src/shared/components/Toast/components/ToastMessage.tsx
@@ -1,17 +1,24 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import * as T from './ToastContainer';
 import { OptionSVG } from './SvgComponents';
-
+import { ToastStore } from 'store/store';
 //Toast Message 컴포넌트 1개
-const ToastMessage = ({ time, content }: { time: number; content: string[] }) => {
+const ToastMessage = ({
+  time,
+  content,
+}: {
+  time: number;
+  content: string[];
+}) => {
   const [show, setShow] = useState(true);
+  
   return (
     <>
       {show && (
         <T.ToastBox time={time}>
           <div className='ToastContent'>
             <label>
-              {content[0]} <br></br>
+              {content[0]} <br/>
               {content[1]}
             </label>
             <OptionSVG onClick={() => setShow(false)} />

--- a/client/src/shared/components/Toast/components/ToastMessage.tsx
+++ b/client/src/shared/components/Toast/components/ToastMessage.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import * as T from './ToastContainer';
 import { OptionSVG } from './SvgComponents';
-import { ToastStore } from 'store/store';
 //Toast Message 컴포넌트 1개
 const ToastMessage = ({
   time,
@@ -11,7 +10,7 @@ const ToastMessage = ({
   content: string[];
 }) => {
   const [show, setShow] = useState(true);
-  
+
   return (
     <>
       {show && (
@@ -20,8 +19,8 @@ const ToastMessage = ({
             <div className='ToastContent'>
               {content[0]} <br />
               {content[1]}
-              </div>  
-          <OptionSVG onClick={() => setShow(false)} />
+            </div>
+            <OptionSVG onClick={() => setShow(false)} />
           </div>
           <T.ProgressBar className='ProgressBar' time={time}></T.ProgressBar>
         </T.ToastBox>

--- a/client/src/shared/components/Toast/hooks/useToast.tsx
+++ b/client/src/shared/components/Toast/hooks/useToast.tsx
@@ -1,0 +1,19 @@
+import { ToastStore } from "store/store";
+
+const useToast = () => {
+    const { addToast, removeToast } = ToastStore();
+
+    const setToast = (time: number, content: string[]) => {
+        
+        let obj = {
+            time,
+            content
+        }
+        addToast(obj);
+        setTimeout(removeToast, time);
+    }
+
+    return { setToast };
+}
+
+export default useToast ;

--- a/client/src/shared/utils/axios.ts
+++ b/client/src/shared/utils/axios.ts
@@ -15,13 +15,12 @@ const jsonInstance = axios.create({
 //form-data용도
 const formdataInstance = axios.create({
 
-  baseURL: 'https://48ce-211-210-144-9.jp.ngrok.io/',
+  baseURL: 'http://localhost:4000',
   timeout: 1000,
   headers: {
     'Content-Type': 'multipart/form-data',
     'ngrok-skip-browser-warning': 'any',
   },
-  // withCredentials: true,
 });
 
 export { jsonInstance, formdataInstance };

--- a/client/src/shared/utils/axios.ts
+++ b/client/src/shared/utils/axios.ts
@@ -15,7 +15,7 @@ const jsonInstance = axios.create({
 //form-data용도
 const formdataInstance = axios.create({
 
-  baseURL: 'http://localhost:4000',
+  baseURL: 'https://3770-211-210-144-9.jp.ngrok.io',
   timeout: 1000,
   headers: {
     'Content-Type': 'multipart/form-data',

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -1,16 +1,7 @@
 import create from 'zustand';
+import { ModalState, Modal, Alarm, Components, Upload } from './types';
 
-interface ModalState {
-  AlertModal: boolean;
-  ProfileModal: boolean;
-}
-
-interface Modal {
-  target: ModalState;
-  openModal: (key: string) => void;
-  closeModal: (key: string) => void;
-  resetTarget: () => void;
-}
+//모달
 const initTarget: ModalState = {
   AlertModal: false,
   ProfileModal: false,
@@ -30,12 +21,7 @@ const ModalStore = create<Modal>((set, get) => ({
     }),
 }));
 
-interface Alarm {
-  alarmIsOpen: boolean;
-  openAlarm: () => void;
-  closeAlarm: () => void;
-}
-
+//알림눌렀을때인데 삭제예정
 const AlarmStore = create<Alarm>((set) => {
   return {
     alarmIsOpen: false,
@@ -50,20 +36,7 @@ const AlarmStore = create<Alarm>((set) => {
   };
 });
 
-interface SubToastState {
-  time: number;
-  content: string[];
-}
-interface ToastState extends SubToastState {
-  id: number;
-}
-
-interface Components {
-  ToastList: ToastState[];
-  addToast: (data: SubToastState) => void;
-  removeToast: () => void;
-}
-
+//Toast Message
 const ToastStore = create<Components>((set, get) => ({
   ToastList: [],
   addToast: (data) =>
@@ -77,19 +50,7 @@ const ToastStore = create<Components>((set, get) => ({
   removeToast: () => set({ ToastList: [...get().ToastList.slice(1)] }),
 }));
 
-interface UploadState {
-  img: File | undefined;
-  title: string;
-  content: string;
-  [key: string]: File | undefined | string;
-}
-
-interface Upload {
-  UploadData: UploadState;
-  setData: (key: string, data: File | string) => void;
-  removeData: () => void;
-}
-
+//upload
 const initUploadData = {
   img: undefined,
   title: '',

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -54,7 +54,7 @@ interface SubToastState {
   time: number;
   content: string[];
 }
-interface ToastState extends SubToastState{
+interface ToastState extends SubToastState {
   id: number;
 }
 
@@ -74,12 +74,7 @@ const ToastStore = create<Components>((set, get) => ({
         ToastList: arr,
       };
     }),
-  removeToast: () =>
-    set(() => {
-      let arr = get().ToastList.slice();
-      arr.shift();
-      return { ToastList: [...arr] };
-    }),
+  removeToast: () => set({ ToastList: [...get().ToastList.slice(1)] }),
 }));
 
 interface UploadState {

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -5,17 +5,16 @@ interface ModalState {
   ProfileModal: boolean;
 }
 
-const initTarget: ModalState = {
-  AlertModal: false,
-  ProfileModal: false,
-};
-
 interface Modal {
   target: ModalState;
   openModal: (key: string) => void;
   closeModal: (key: string) => void;
   resetTarget: () => void;
 }
+const initTarget: ModalState = {
+  AlertModal: false,
+  ProfileModal: false,
+};
 
 const ModalStore = create<Modal>((set, get) => ({
   target: { ...initTarget },
@@ -51,15 +50,17 @@ const AlarmStore = create<Alarm>((set) => {
   };
 });
 
-interface ToastState {
+interface SubToastState {
   time: number;
   content: string[];
+}
+interface ToastState extends SubToastState{
   id: number;
 }
 
 interface Components {
   ToastList: ToastState[];
-  addToast: (data: ToastState) => void;
+  addToast: (data: SubToastState) => void;
   removeToast: () => void;
 }
 
@@ -68,7 +69,7 @@ const ToastStore = create<Components>((set, get) => ({
   addToast: (data) =>
     set(() => {
       let arr = get().ToastList.slice();
-      arr.push({ ...data });
+      arr.push({ ...Object.assign({}, data, { id: Math.random() }) });
       return {
         ToastList: arr,
       };
@@ -81,4 +82,31 @@ const ToastStore = create<Components>((set, get) => ({
     }),
 }));
 
-export { ModalStore, AlarmStore, ToastStore };
+interface UploadState {
+  img: File | undefined;
+  title: string;
+  content: string;
+  [key: string]: File | undefined | string;
+}
+
+interface Upload {
+  UploadData: UploadState;
+  setData: (key: string, data: File | string) => void;
+  removeData: () => void;
+}
+
+const initUploadData = {
+  img: undefined,
+  title: '',
+  content: '',
+};
+
+const UploadStore = create<Upload>((set, get) => ({
+  UploadData: { ...initUploadData },
+  setData: (key, data) =>
+    set({
+      UploadData: { ...Object.assign(get().UploadData, { [key]: data }) },
+    }),
+  removeData: () => set({ UploadData: { ...initUploadData } }),
+}));
+export { ModalStore, AlarmStore, ToastStore, UploadStore };

--- a/client/src/store/types.ts
+++ b/client/src/store/types.ts
@@ -1,0 +1,44 @@
+export interface ModalState {
+  AlertModal: boolean;
+  ProfileModal: boolean;
+}
+
+export interface Modal {
+  target: ModalState;
+  openModal: (key: string) => void;
+  closeModal: (key: string) => void;
+  resetTarget: () => void;
+}
+
+export interface Alarm {
+  alarmIsOpen: boolean;
+  openAlarm: () => void;
+  closeAlarm: () => void;
+}
+
+export interface SubToastState {
+  time: number;
+  content: string[];
+}
+export interface ToastState extends SubToastState {
+  id: number;
+}
+
+export interface Components {
+  ToastList: ToastState[];
+  addToast: (data: SubToastState) => void;
+  removeToast: () => void;
+}
+
+export interface UploadState {
+  img: File | undefined;
+  title: string;
+  content: string;
+  [key: string]: File | undefined | string;
+}
+
+export interface Upload {
+  UploadData: UploadState;
+  setData: (key: string, data: File | string) => void;
+  removeData: () => void;
+}

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -14,3 +14,7 @@ declare module "*.gif"{
     const value: any;
     export = value;
 };
+declare module "*.svg"{
+    const value: any;
+    export = value;
+};


### PR DESCRIPTION
### 구현기능
- Toast Message 구조 변경
- Alert Modal 구조변경
- 업로드페이지 기능 + 통신 구현

### 구현상세 
#### Toast Message 구조 변경
- 기존 조금 복잡하던 Toast Message 실행방식을 바꿨습니다. 추후 바뀔 예정이 없으므로 이 로직으로 사용하시면 됩니다.
- custom hook으로 바꿨으므로 상단에 import, 선언해주시고 setToast로 띄어질 시간, 데이터 입력하시면 됩니다.
``` javascript
import useToast from 'shared/components/Toast/hooks/useToast';
const { setToast } = useToast();
setToast(3000, ['작품이 등록되었습니다.', '내 전시관도 만들어보기']);

```
#### Alert Modal 구조변경
- AlertData.ts 파일을 만들었으므로 사용할때 해당 파일에 원하는 데이터 추가후 Alert에 props로 내려서 쓰시면 됩니다.

#### 업로드페이지 기능 + 통신구현
- 사진업로드기능을 구현했고 사진 비율에 따라 보이도록 했습니다.
- 제목은 15글자이하, 내용은 30글자이하, 확장자검사 까지했고 사진파일 크기는 따로 설정하지 않았습니다.(추가가능)
<img width="487" alt="image" src="https://user-images.githubusercontent.com/86215246/203891789-9c66d768-0cdf-4175-8d52-0fe560918d57.png">


