### PR TITLE
Feat/#119 re

### DIFF
--- a/client/src/Gallery/components/GalleryInfo/index.tsx
+++ b/client/src/Gallery/components/GalleryInfo/index.tsx
@@ -1,16 +1,21 @@
 import React from 'react';
 import * as S from './style';
+import { loginStore } from 'store/store';
+import { useGalleryData } from 'GallerySetting/hooks/useGalleryData';
 
-const index = () => {
+const Index = () => {
   // api에서 title, content 받아오기
+  const { user } = loginStore();
+  const galleryId = user?.galleryId;
+  const { data } = useGalleryData(galleryId!);
   return (
     <div>
       <S.Info>
-        <h2>오은의 1년 졸업 전시회</h2>
-        <div>저의 1년에 대해 재밌는 사진들이나 추억을 올려주세요</div>
+        <h2>{data.title}</h2>
+        <div>{data.content}</div>
       </S.Info>
     </div>
   );
 };
 
-export default index;
+export default Index;

--- a/client/src/Gallery/hooks/useLikeData.ts
+++ b/client/src/Gallery/hooks/useLikeData.ts
@@ -1,14 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { jsonInstance } from 'shared/utils/axios';
-import { loginStore } from 'store/store';
 
-const { user } = loginStore();
-const galleryId = user?.galleryId;
-
-export function useLikeData() {
-  const { data, isLoading } = useQuery(['like'], () =>
-    jsonInstance.get(`/galleries/${galleryId}/artworks`),
+export function useLikeData(galleryId: number) {
+  return useQuery(
+    ['like'],
+    () => jsonInstance.get(`/galleries/${galleryId}/artworks/like`),
+    { select: (data) => data?.data },
   );
-
-  return data?.data;
 }

--- a/client/src/GallerySetting/GallerySetting.tsx
+++ b/client/src/GallerySetting/GallerySetting.tsx
@@ -1,27 +1,37 @@
 import Input from './components/Input';
-import { jsonInstance } from 'shared/utils/axios';
 import { useGalleryData } from './hooks/useGalleryData';
-import { getGallery, updateGallery, postGallery } from './api';
+import { patchGallery, postGallery, deleteGalleryById } from './api';
 import { loginStore } from 'store/store';
-import { useNavigate } from 'react-router-dom';
-// const postGallery = (form: { title: string; content: string }) => {
-//   // return jsonInstance.post(`/galleries/${galleryId}`, form);
-//   // return jsonInstance.post(`/galleries`, form);
-//   console.log(form);
-// };
+import { getUser } from 'Intro/api';
 
 const GallerySetting = () => {
   const { user } = loginStore();
+  const setUser = loginStore((state) => state.setUser);
   const galleryId = user?.galleryId;
-  const navigate = useNavigate();
+
+  // 전시관 확인용
+  const { data } = useGalleryData(galleryId!);
+  console.log(data);
+
   const onSubmit = (form: { title: string; content: string }) => {
-    console.log(form);
-    navigate('/uploadPicture');
-    // galleryId !== null ? updateGallery(form) : postGallery(form);
+    galleryId !== null
+      ? patchGallery(form)
+      : postGallery(form).then((res) => {
+          setUser(res.data);
+        });
+  };
+
+  const onClick = () => {
+    deleteGalleryById();
+    // TODO: galleryId null 처리 목적 - GET 요청 안 보내는 방향으로 추후 수정
+    getUser().then((res) => {
+      setUser(res.data);
+    });
   };
 
   return (
     <div>
+      <button onClick={onClick}>전시관 폐쇄</button>
       <Input onSubmit={onSubmit} />
     </div>
   );

--- a/client/src/GallerySetting/api.tsx
+++ b/client/src/GallerySetting/api.tsx
@@ -1,9 +1,5 @@
 import { jsonInstance } from 'shared/utils/axios';
 import GalleryType from './galleryType';
-import { loginStore } from 'store/store';
-
-const { user } = loginStore();
-const galleryId = user?.galleryId;
 
 // 전시관 등록
 export const postGallery = async ({ title, content }: GalleryType) => {
@@ -14,16 +10,13 @@ export const postGallery = async ({ title, content }: GalleryType) => {
 };
 
 // 전시관 조회
-export const getGallery = async () => {
+export const getGallery = async (galleryId: number) => {
   return await jsonInstance.get<any>(`/galleries/${galleryId}`);
 };
 
 // 전시관 수정
-export const updateGallery = async ({
-  title,
-  content,
-}: GalleryType) => {
-  return await jsonInstance.put<any>(`/galleries/me`, {
+export const patchGallery = async ({ title, content }: GalleryType) => {
+  return await jsonInstance.patch<any>(`/galleries/me`, {
     title,
     content,
   });

--- a/client/src/GallerySetting/hooks/useGalleryData.ts
+++ b/client/src/GallerySetting/hooks/useGalleryData.ts
@@ -1,10 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
-import { jsonInstance } from 'shared/utils/axios';
+import { getGallery } from '../api';
 
-export function useGalleryData(galleryId: number) {
-  const { data, isLoading } = useQuery(['galleries'], () =>
-    jsonInstance.get(`/galleries/${galleryId}`),
-  );
-
-  return data?.data;
-}
+export const useGalleryData = (galleryId: number) => {
+  return useQuery(['galleries'], () => getGallery(galleryId), {
+    select: (data: any) => {
+      return data?.data;
+    },
+  });
+};

--- a/client/src/Intro/Redirect.tsx
+++ b/client/src/Intro/Redirect.tsx
@@ -1,0 +1,22 @@
+import path from 'path';
+import { useEffect } from 'react';
+import { useNavigate, Navigate, useLocation, Link } from 'react-router-dom';
+import { loginStore } from 'store/store';
+
+const Redirect = () => {
+  // 로그인 여부를 불러온다
+  const { isLoggedin, setIsLoggedIn } = loginStore();
+  const { pathname } = useLocation();
+  const login_url = process.env.REACT_APP_KAKAO_AUTH_URL;
+  return (
+    <>
+      {isLoggedin ? (
+        <Navigate to={pathname} />
+      ) : (
+        window.location.replace(login_url!)
+      )}
+    </>
+  );
+};
+
+export default Redirect;

--- a/client/src/Intro/RedirectPage.tsx
+++ b/client/src/Intro/RedirectPage.tsx
@@ -53,11 +53,6 @@ const RedirectPage = (): ReactElement => {
       <button>
         <StyledLink to={'/gallerySetting'}>전시관 구경 가기</StyledLink>
       </button>
-      <button>
-        <StyledLink to={'/gallerySetting'}>
-          이전 페이지로 돌아가기(아직 구현 x)
-        </StyledLink>
-      </button>
     </>
   );
 };

--- a/client/src/Intro/api.ts
+++ b/client/src/Intro/api.ts
@@ -1,12 +1,16 @@
 import { jsonInstance } from 'shared/utils/axios';
 
+// 회원 조회
+export const getUser = async () => {
+  return await jsonInstance.get<any>('/members/me');
+};
 
 // 로그아웃
 export const logout = async () => {
   return await jsonInstance.post<any>('/logout');
-}
+};
 
-// 회원 조회
-export const getUser = async () => {
-  return await jsonInstance.get<any>('/members/me');
-}
+// 회원 탈퇴
+export const deleteUser = async () => {
+  return await jsonInstance.delete<any>('/members/me');
+};


### PR DESCRIPTION
## 구현 목록
### 회원 API

- [x] 회원 탈퇴 API 추가

### 전시관 API

- [x] API 리팩토링
- [x] useQuery 리팩토링
- [x] post(전시관 등록) 시, 유저 정보 다시 받아오기
- [x] delete(전시관 폐쇄) 시, 유저 정보 다시 받아오기

### 리다이렉트

- 로그인 여부에 따라 카카오 로그인 페이지로 리다이렉트 하거나, 가려고 하는 페이지로 보내는 기능 구현
- 실제 돌아가는지 확인 필요 후 적용 예정이라 App.tsx에는 아직 반영하지 않음

## 이후 구현
- 리다이렉트 확인
- 전시관에 사진 띄우기
- 사이트 소개 페이지