### PR TITLE
[BE] 카카오 연결끊기 구현, test db 환경 분리

### DIFF
--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/member/controller/MemberController.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.codestates.mainproject.oneyearfourcut.domain.member.controller;
 
+import com.codestates.mainproject.oneyearfourcut.domain.gallery.service.GalleryService;
 import com.codestates.mainproject.oneyearfourcut.domain.member.dto.MemberRequestDto;
 import com.codestates.mainproject.oneyearfourcut.domain.member.dto.MemberResponseDto;
 import com.codestates.mainproject.oneyearfourcut.domain.member.entity.Member;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService memberService;
+    private final GalleryService galleryService;
 
     //회원 조회
     @GetMapping("/me")
@@ -28,7 +30,7 @@ public class MemberController {
     public ResponseEntity patchMember(@LoginMember Long memberId,
                                       @ModelAttribute MemberRequestDto memberRequestDto) {
         //회원 수정 시에 프로필, 이름을 한번에 변경할건지 프론트와 의논해봐야함
-        MemberResponseDto memberResponseDto = memberService.modifyMember(memberId, memberRequestDto);
+        memberService.modifyMember(memberId, memberRequestDto);
 
         return new ResponseEntity("회원 수정 성공", HttpStatus.OK);
     }
@@ -37,6 +39,7 @@ public class MemberController {
     @DeleteMapping("/me")
     public ResponseEntity deleteMember(@LoginMember Long memberId) {
         memberService.deleteMember(memberId);
+        galleryService.deleteGallery(memberId);
 
         return new ResponseEntity("회원 탈퇴 성공", HttpStatus.NO_CONTENT);
     }

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/member/entity/Member.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/domain/member/entity/Member.java
@@ -31,6 +31,8 @@ public class Member extends Auditable {
 
     private String profile;
 
+    private Long kakaoId;
+
     @Enumerated(EnumType.STRING)
     private Role role;
 
@@ -38,12 +40,13 @@ public class Member extends Auditable {
     private MemberStatus status;
 
     @Builder
-    public Member(String nickname, String email, String profile, Role role, MemberStatus status) {
+    public Member(String nickname, String email, String profile, Role role, MemberStatus status, Long kakaoId) {
         this.nickname = nickname;
         this.email = email;
         this.profile = profile;
         this.role = role;
         this.status = status;
+        this.kakaoId = kakaoId;
     }
 
     //jpa 연관관계 맵핑 위해 생성하는 member 엔티티 용 생성자
@@ -60,6 +63,9 @@ public class Member extends Auditable {
 
     public void updateStatus(MemberStatus status) {
         this.status = status;
+    }
+    public void updateKakaoId(Long kakaoId) {
+        this.kakaoId = kakaoId;
     }
 
     public MemberResponseDto toMemberResponseDto() {

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/global/config/RestTemplateConfig.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/global/config/RestTemplateConfig.java
@@ -1,0 +1,25 @@
+package com.codestates.mainproject.oneyearfourcut.global.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.Charset;
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+                .requestFactory(() -> new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()))
+                .setConnectTimeout(Duration.ofMillis(5000)) // connection-timeout
+                .setReadTimeout(Duration.ofMillis(5000)) // read-timeout
+                .additionalMessageConverters(new StringHttpMessageConverter(Charset.forName("UTF-8")))
+                .build();
+    }
+}

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/global/config/auth/SecurityConfig.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/global/config/auth/SecurityConfig.java
@@ -82,6 +82,7 @@ public class SecurityConfig {
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setAllowCredentials(true);
         configuration.addExposedHeader("Authorization");
+        configuration.addExposedHeader("refresh");  //커스텀 헤더를 보이도록 하는 것
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();   //  CorsConfigurationSource 인터페이스의 구현 클래스인 UrlBasedCorsConfigurationSource 클래스의 객체를 생성한다.
         source.registerCorsConfiguration("/**", configuration);

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/global/config/auth/handler/OAuth2MemberSuccessHandler.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/global/config/auth/handler/OAuth2MemberSuccessHandler.java
@@ -5,7 +5,6 @@ import com.codestates.mainproject.oneyearfourcut.domain.member.entity.MemberStat
 import com.codestates.mainproject.oneyearfourcut.domain.member.entity.Role;
 import com.codestates.mainproject.oneyearfourcut.domain.member.service.MemberService;
 import com.codestates.mainproject.oneyearfourcut.global.config.auth.jwt.JwtTokenizer;
-import com.codestates.mainproject.oneyearfourcut.domain.refreshToken.entity.RefreshToken;
 import com.codestates.mainproject.oneyearfourcut.domain.refreshToken.service.RefreshTokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -20,7 +19,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URI;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +34,7 @@ public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         var oAuth2User = (OAuth2User)authentication.getPrincipal();
         Map<String, Object> attributes = oAuth2User.getAttributes();
+        Long kakaoId = (Long) attributes.get("id");
 
         // kakao는 kakao_account에 유저정보가 있다. (email)
         Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get("kakao_account");
@@ -47,17 +46,18 @@ public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
         String profile = (String) kakaoProfile.get("profile_image_url");
         List<String> authorities = List.of("USER"); //일단 모든유저 역할 통일
 
-        saveMember(email, nickname, profile);
+        saveMember(email, nickname, profile, kakaoId);
         redirect(request, response, email, authorities);
     }
 
-    private void saveMember(String email, String nickname, String profile) {
+    private void saveMember(String email, String nickname, String profile, Long kakaoId) {
         Member member = Member.builder()
                 .email(email)
                 .nickname(nickname)
                 .profile(profile)
                 .role(Role.USER)
                 .status(MemberStatus.ACTIVE)
+                .kakaoId(kakaoId)
                 .build();
         memberService.createMember(member);
     }

--- a/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/global/exception/exception/ExceptionCode.java
+++ b/server/oneyearfourcut/src/main/java/com/codestates/mainproject/oneyearfourcut/global/exception/exception/ExceptionCode.java
@@ -23,7 +23,7 @@ public enum ExceptionCode {
     NO_ACEESS_TOKEN(400, "Access Token이 header에 없습니다."),
     NO_REFRESH_TOKEN(400, "Refresh Token이 header에 없습니다."),
     //파일 관련
-    EXCEEDED_FILE_SIZE(400, "파일 사이즈가 5MB를 초과하였습니다."),
+    EXCEEDED_FILE_SIZE(400, "파일 사이즈가 10MB를 초과하였습니다."),
     INVALID_FILE_TYPE(400, "잘못된 파일명입니다."),
     UNSUPPORTED_FILE_EXTENSION(400, "지원하지 않는 확장자입니다.");
 

--- a/server/oneyearfourcut/src/main/resources/application-real.yml
+++ b/server/oneyearfourcut/src/main/resources/application-real.yml
@@ -7,3 +7,8 @@ spring:
         dialect: org.hibernate.dialect.MySQL5InnoDBDialect
   session:
     store-type: jdbc
+  # 이미지 파일 용량 제한 수정
+  servlet:
+    multipart:
+      maxFileSize: 10MB
+      maxRequestSize: 10MB

--- a/server/oneyearfourcut/src/main/resources/application.yml
+++ b/server/oneyearfourcut/src/main/resources/application.yml
@@ -38,5 +38,5 @@ spring:
   # 이미지 파일 용량 제한 수정
   servlet:
     multipart:
-      maxFileSize: 5MB
-      maxRequestSize: 5MB
+      maxFileSize: 10MB
+      maxRequestSize: 10MB

--- a/server/oneyearfourcut/src/main/resources/static/docs/index.html
+++ b/server/oneyearfourcut/src/main/resources/static/docs/index.html
@@ -520,7 +520,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/members/me' -i -X GET \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMSwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNzYsImV4cCI6MTY3MDA0NDc3Nn0.EiIjSy_gtDCCiKi_HVWtPypOUF1c76-wcbjzsyrKxI2Xdl-fc24ooqB_Mn2iIGUo' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMSwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzcsImV4cCI6MTY3MDA4NTUzN30.Dr9KEJDhtbBBPbmNFrXeiLtv4pTRntNHyrPGQF4HdjGud_Qv0ICpoYJjyR1PhzUD' \
     -H 'Accept: application/json'</code></pre>
 </div>
 </div>
@@ -529,7 +529,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /members/me HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMSwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNzYsImV4cCI6MTY3MDA0NDc3Nn0.EiIjSy_gtDCCiKi_HVWtPypOUF1c76-wcbjzsyrKxI2Xdl-fc24ooqB_Mn2iIGUo
+Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMSwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzcsImV4cCI6MTY3MDA4NTUzN30.Dr9KEJDhtbBBPbmNFrXeiLtv4pTRntNHyrPGQF4HdjGud_Qv0ICpoYJjyR1PhzUD
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -567,7 +567,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: SAMEORIGIN
-Content-Length: 76
+Content-Length: 72
 
 {
   "nickname" : "홍길동",
@@ -616,7 +616,7 @@ Content-Length: 76
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/members/me' -i -X POST \
     -H 'Content-Type: multipart/form-data;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNzYsImV4cCI6MTY3MDA0NDc3Nn0.25sOWuIifZ4UdHt7SuA5E6JSM3_oERyEXI4ucpfDdlKy5rL_DCAXWS6GvtdaifWx' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzcsImV4cCI6MTY3MDA4NTUzN30.iqRH3JS-2OUyspJjfXIPneY36hYjB5CyAL5Vq4Z2N5fK_Dv6VBVZKjpPoG8K60uE' \
     -F 'profile=@profile;type=image/jpeg' \
     -F 'nickname=수정된 이름'</code></pre>
 </div>
@@ -626,7 +626,7 @@ Content-Length: 76
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /members/me HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNzYsImV4cCI6MTY3MDA0NDc3Nn0.25sOWuIifZ4UdHt7SuA5E6JSM3_oERyEXI4ucpfDdlKy5rL_DCAXWS6GvtdaifWx
+Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzcsImV4cCI6MTY3MDA4NTUzN30.iqRH3JS-2OUyspJjfXIPneY36hYjB5CyAL5Vq4Z2N5fK_Dv6VBVZKjpPoG8K60uE
 Host: localhost:8080
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -724,14 +724,14 @@ X-Frame-Options: SAMEORIGIN
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/members/me' -i -X DELETE \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY2OTk1ODM3NiwiZXhwIjoxNjcwMDQ0Nzc2fQ.mhZPK6kAKhfdg0gcB_WQaHWjwxKUQKVjs2TKE5P-4iz7RktpkGPQ6s9bs13p_Z59'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY3MDA4NDkzNywiZXhwIjoxNjcwMDg1NTM3fQ.UfIdvZy-5LSTt9yAuIPgLGTfiZLroDNMp1HJEdFIr4X9eUTpte-EuGw4DLiHlGRC'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /members/me HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY2OTk1ODM3NiwiZXhwIjoxNjcwMDQ0Nzc2fQ.mhZPK6kAKhfdg0gcB_WQaHWjwxKUQKVjs2TKE5P-4iz7RktpkGPQ6s9bs13p_Z59
+Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY3MDA4NDkzNywiZXhwIjoxNjcwMDg1NTM3fQ.UfIdvZy-5LSTt9yAuIPgLGTfiZLroDNMp1HJEdFIr4X9eUTpte-EuGw4DLiHlGRC
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -869,7 +869,7 @@ Host: localhost:8080</code></pre>
 <div class="title">http-response</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">HTTP/1.1 201 Created
-Authorization: Bearer Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY2OTgyNzA2OCwiZXhwIjoxNjY5ODI3MTI4fQ.xNAhFxDcKKHGqvDfh7LQhtJyGzqq2mbjC30adPqPGLzVhmmGlze17Zbaue1LrgxO'
+Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY2OTgyNzA2OCwiZXhwIjoxNjY5ODI3MTI4fQ.xNAhFxDcKKHGqvDfh7LQhtJyGzqq2mbjC30adPqPGLzVhmmGlze17Zbaue1LrgxO'
 refresh: eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY2OTgyNzA2OCwiZXhwIjoxNjY5ODI3MTI4fQ.xNAhFxDcKKHGqvDfh7LQhtJyGzqq2mbjC30adPqPGLzVhmmGlze17Zbaue1LrgxO'
 Content-Type: text/plain;charset=UTF-8
 Content-Length: 39
@@ -923,7 +923,7 @@ X-Frame-Options: DENY
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNzQsImV4cCI6MTY3MDA0NDc3NH0.RH5LqyYmvu-9y4C19Nz3YtiNjTShc5lj-0O5zjNixtWp0zWu0Iv-JGvZXCJuOemL' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzYsImV4cCI6MTY3MDA4NTUzNn0._2aEVQ3JtM5i2P6GH-Y1r1z3gZ0TfPtd_sDb7l6oucyM69sfxiK8_Dl1fUR3mLjG' \
     -H 'Accept: application/json' \
     -d '{
   "title" : "나의 전시관",
@@ -936,9 +936,9 @@ X-Frame-Options: DENY
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /galleries HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNzQsImV4cCI6MTY3MDA0NDc3NH0.RH5LqyYmvu-9y4C19Nz3YtiNjTShc5lj-0O5zjNixtWp0zWu0Iv-JGvZXCJuOemL
+Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzYsImV4cCI6MTY3MDA4NTUzNn0._2aEVQ3JtM5i2P6GH-Y1r1z3gZ0TfPtd_sDb7l6oucyM69sfxiK8_Dl1fUR3mLjG
 Accept: application/json
-Content-Length: 70
+Content-Length: 67
 Host: localhost:8080
 
 {
@@ -1007,13 +1007,13 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: SAMEORIGIN
-Content-Length: 137
+Content-Length: 132
 
 {
   "galleryId" : 4,
   "title" : "나의 전시관",
   "content" : "안녕하세요",
-  "createdAt" : "2022-12-02T14:19:34.193374"
+  "createdAt" : "2022-12-04T01:28:56.145184"
 }</code></pre>
 </div>
 </div>
@@ -1107,13 +1107,13 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: SAMEORIGIN
-Content-Length: 137
+Content-Length: 132
 
 {
   "galleryId" : 5,
   "title" : "나의 전시관",
   "content" : "안녕하세요",
-  "createdAt" : "2022-12-02T14:19:34.219928"
+  "createdAt" : "2022-12-04T01:28:56.170374"
 }</code></pre>
 </div>
 </div>
@@ -1162,7 +1162,7 @@ Content-Length: 137
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/me' -i -X PATCH \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMSwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNzQsImV4cCI6MTY3MDA0NDc3NH0.v2C-1wPDmdaDsDTEwPMIxIkwZdWQubSG4bIOVpPCKsaqc2Wzb_4-V4Ule-gZAKTw' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMSwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzYsImV4cCI6MTY3MDA4NTUzNn0.BfbCcybdr0ZUan3tNDeH1Rt4LgOVEQ9FlhG1dSQjQWhmSymX84Ko2lrYqHqOJ3dF' \
     -H 'Accept: application/json' \
     -d '{
   "title" : "수정된 제목",
@@ -1175,9 +1175,9 @@ Content-Length: 137
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">PATCH /galleries/me HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMSwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNzQsImV4cCI6MTY3MDA0NDc3NH0.v2C-1wPDmdaDsDTEwPMIxIkwZdWQubSG4bIOVpPCKsaqc2Wzb_4-V4Ule-gZAKTw
+Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMSwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzYsImV4cCI6MTY3MDA4NTUzNn0.BfbCcybdr0ZUan3tNDeH1Rt4LgOVEQ9FlhG1dSQjQWhmSymX84Ko2lrYqHqOJ3dF
 Accept: application/json
-Content-Length: 71
+Content-Length: 68
 Host: localhost:8080
 
 {
@@ -1259,7 +1259,7 @@ X-Frame-Options: SAMEORIGIN
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/me' -i -X DELETE \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY2OTk1ODM3NCwiZXhwIjoxNjcwMDQ0Nzc0fQ.43XK9IPQ844QE3j9aL6uyKRbvdWZ7BXfvc8_xL-9aj2iEGyrxK3WEDItfm4qa8tr' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY3MDA4NDkzNiwiZXhwIjoxNjcwMDg1NTM2fQ.omcKZIHd3CQxbQuaSeStHIS9M1a2Ss3eX5r6UvHfwmknBLovJ3_7D9EG8e1tWAJJ' \
     -H 'Accept: application/json'</code></pre>
 </div>
 </div>
@@ -1268,7 +1268,7 @@ X-Frame-Options: SAMEORIGIN
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /galleries/me HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY2OTk1ODM3NCwiZXhwIjoxNjcwMDQ0Nzc0fQ.43XK9IPQ844QE3j9aL6uyKRbvdWZ7BXfvc8_xL-9aj2iEGyrxK3WEDItfm4qa8tr
+Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY3MDA4NDkzNiwiZXhwIjoxNjcwMDg1NTM2fQ.omcKZIHd3CQxbQuaSeStHIS9M1a2Ss3eX5r6UvHfwmknBLovJ3_7D9EG8e1tWAJJ
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -1518,7 +1518,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 1068
+Content-Length: 1023
 
 [ {
   "artworkId" : 1,
@@ -1696,7 +1696,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 211
+Content-Length: 202
 
 {
   "artworkId" : 1,
@@ -1813,7 +1813,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 337
+Content-Length: 321
 
 [ {
   "artworkId" : 1,
@@ -1986,7 +1986,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 207
+Content-Length: 198
 
 {
   "artworkId" : 1,
@@ -2223,7 +2223,7 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/1/comments' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxNCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNzAsImV4cCI6MTY3MDA0NDc3MH0.K6fmo5wQEs63LFozIttBLIipm4rLFe2wlwPw3iT56-KBK_JVJlrEqcRm63EraYlC' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxNCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzMsImV4cCI6MTY3MDA4NTUzM30.uksku7UbXNDQzA7zPU1bhOhHes47QQujDCk8cSYKSbhRPLZ0x2qFUDC930hrfR3q' \
     -H 'Accept: application/json' \
     -d '{
   "content" : "댓글입니다"
@@ -2235,9 +2235,9 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /galleries/1/comments HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxNCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNzAsImV4cCI6MTY3MDA0NDc3MH0.K6fmo5wQEs63LFozIttBLIipm4rLFe2wlwPw3iT56-KBK_JVJlrEqcRm63EraYlC
+Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxNCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzMsImV4cCI6MTY3MDA4NTUzM30.uksku7UbXNDQzA7zPU1bhOhHes47QQujDCk8cSYKSbhRPLZ0x2qFUDC930hrfR3q
 Accept: application/json
-Content-Length: 37
+Content-Length: 35
 Host: localhost:8080
 
 {
@@ -2297,7 +2297,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: SAMEORIGIN
-Content-Length: 272
+Content-Length: 261
 
 {
   "galleryId" : 1,
@@ -2321,7 +2321,7 @@ Content-Length: 272
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/1/artworks/1/comments' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMywidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNzAsImV4cCI6MTY3MDA0NDc3MH0.nMiMq-mL06YB-8LCLg0L77Fi7uba3vi7TUJqfBcopPXPHa_W1qmlQbJahZjmGrXa' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMywidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzMsImV4cCI6MTY3MDA4NTUzM30.X9i5K6sEj5WQ9gOIXKQ4hP2jyeBmTPnsHCyWNNw_-m6aY4vFX8370NFawc9Xb_9C' \
     -H 'Accept: application/json' \
     -d '{
   "content" : "댓글입니다"
@@ -2333,9 +2333,9 @@ Content-Length: 272
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /galleries/1/artworks/1/comments HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMywidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNzAsImV4cCI6MTY3MDA0NDc3MH0.nMiMq-mL06YB-8LCLg0L77Fi7uba3vi7TUJqfBcopPXPHa_W1qmlQbJahZjmGrXa
+Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMywidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzMsImV4cCI6MTY3MDA4NTUzM30.X9i5K6sEj5WQ9gOIXKQ4hP2jyeBmTPnsHCyWNNw_-m6aY4vFX8370NFawc9Xb_9C
 Accept: application/json
-Content-Length: 37
+Content-Length: 35
 Host: localhost:8080
 
 {
@@ -2399,7 +2399,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: SAMEORIGIN
-Content-Length: 267
+Content-Length: 256
 
 {
   "galleryId" : 1,
@@ -2487,7 +2487,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: SAMEORIGIN
-Content-Length: 873
+Content-Length: 840
 
 {
   "galleryId" : 4,
@@ -2601,7 +2601,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: SAMEORIGIN
-Content-Length: 398
+Content-Length: 381
 
 {
   "galleryId" : 6,
@@ -2631,7 +2631,7 @@ Content-Length: 398
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/5/comments/5' -i -X PATCH \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMSwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNzAsImV4cCI6MTY3MDA0NDc3MH0.e0B53VsRbsuVmdfu7rRgopLHo14fzjsRXKIMsYcTWJLFFmAXcanvGy8BoQ06H6Xl' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMSwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzMsImV4cCI6MTY3MDA4NTUzM30.4WLKZTD-JIVLbx5Q_IRDqkdOPkjL5lE8-ErloXQDWnTjVyZnIhlX1VtgCqrycaRo' \
     -H 'Accept: application/json' \
     -d '{
   "content" : "수정댓글입니다."
@@ -2643,9 +2643,9 @@ Content-Length: 398
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">PATCH /galleries/5/comments/5 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMSwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNzAsImV4cCI6MTY3MDA0NDc3MH0.e0B53VsRbsuVmdfu7rRgopLHo14fzjsRXKIMsYcTWJLFFmAXcanvGy8BoQ06H6Xl
+Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMSwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzMsImV4cCI6MTY3MDA4NTUzM30.4WLKZTD-JIVLbx5Q_IRDqkdOPkjL5lE8-ErloXQDWnTjVyZnIhlX1VtgCqrycaRo
 Accept: application/json
-Content-Length: 44
+Content-Length: 42
 Host: localhost:8080
 
 {
@@ -2709,7 +2709,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: SAMEORIGIN
-Content-Length: 279
+Content-Length: 268
 
 {
   "galleryId" : 5,
@@ -2733,7 +2733,7 @@ Content-Length: 279
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/3/comments/5' -i -X DELETE \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY2OTk1ODM3MCwiZXhwIjoxNjcwMDQ0NzcwfQ.wWRMfoTYMPrkOuKV5gDlc62YRBl3ZWgtize9HbsBnh-2dQvtqCDC0jwVplE4q6gn' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY3MDA4NDkzMywiZXhwIjoxNjcwMDg1NTMzfQ.ateHpY_FGisYEIb9IM3lxCOrWugxJuiJYOGMbMo_7tNa8CiZirDEGWOdK2LgUO4j' \
     -H 'Accept: application/json'</code></pre>
 </div>
 </div>
@@ -2742,7 +2742,7 @@ Content-Length: 279
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /galleries/3/comments/5 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY2OTk1ODM3MCwiZXhwIjoxNjcwMDQ0NzcwfQ.wWRMfoTYMPrkOuKV5gDlc62YRBl3ZWgtize9HbsBnh-2dQvtqCDC0jwVplE4q6gn
+Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY3MDA4NDkzMywiZXhwIjoxNjcwMDg1NTMzfQ.ateHpY_FGisYEIb9IM3lxCOrWugxJuiJYOGMbMo_7tNa8CiZirDEGWOdK2LgUO4j
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -2818,7 +2818,7 @@ X-Frame-Options: SAMEORIGIN</code></pre>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/comments/1/replies' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNzIsImV4cCI6MTY3MDA0NDc3Mn0.WxgXc-nqu-vyDgLQDp6XtmauaB5s4paTkA2xEAPiPQFEaBn24CrU5rtV2t8CAJLD' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzQsImV4cCI6MTY3MDA4NTUzNH0.DkmBX1Poqu_uJh7O3CCcidCxFStlAQ_ScknOTSVukGgO4RVBzWi_pHrSqLVU7kl3' \
     -H 'Accept: application/json' \
     -d '{
   "content" : "답글입니다"
@@ -2830,9 +2830,9 @@ X-Frame-Options: SAMEORIGIN</code></pre>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /galleries/comments/1/replies HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNzIsImV4cCI6MTY3MDA0NDc3Mn0.WxgXc-nqu-vyDgLQDp6XtmauaB5s4paTkA2xEAPiPQFEaBn24CrU5rtV2t8CAJLD
+Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzQsImV4cCI6MTY3MDA4NTUzNH0.DkmBX1Poqu_uJh7O3CCcidCxFStlAQ_ScknOTSVukGgO4RVBzWi_pHrSqLVU7kl3
 Accept: application/json
-Content-Length: 37
+Content-Length: 35
 Host: localhost:8080
 
 {
@@ -2892,7 +2892,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: SAMEORIGIN
-Content-Length: 243
+Content-Length: 233
 
 {
   "commentId" : 1,
@@ -2960,7 +2960,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: SAMEORIGIN
-Content-Length: 672
+Content-Length: 648
 
 {
   "commentId" : 1,
@@ -2970,7 +2970,7 @@ Content-Length: 672
     "nickname" : "test1",
     "content" : "답글",
     "createdAt" : "2022-11-14T23:41:52.764644",
-    "modifiedAt" : "2022-12-02T14:19:32.530146"
+    "modifiedAt" : "2022-12-04T01:28:54.924666"
   }, {
     "replyId" : 2,
     "memberId" : 1,
@@ -2997,7 +2997,7 @@ Content-Length: 672
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/comments/4/replies/1' -i -X PATCH \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMiwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNzIsImV4cCI6MTY3MDA0NDc3Mn0.eLJXXy9DzKijEoN4zO3QKINFpfT1GO0o5wyeMnA1YrmxXTVN9JPAa9pq0_aLHM-i' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMiwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzQsImV4cCI6MTY3MDA4NTUzNH0.bH3AUEov0hDi0vxZnEwU0HXtWGwQR4I74tjGvmOxnuFHy1mNOCk3S64AYN3CCk4t' \
     -H 'Accept: application/json' \
     -d '{
   "content" : "수정대댓글입니다."
@@ -3009,9 +3009,9 @@ Content-Length: 672
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">PATCH /galleries/comments/4/replies/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMiwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNzIsImV4cCI6MTY3MDA0NDc3Mn0.eLJXXy9DzKijEoN4zO3QKINFpfT1GO0o5wyeMnA1YrmxXTVN9JPAa9pq0_aLHM-i
+Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMiwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzQsImV4cCI6MTY3MDA4NTUzNH0.bH3AUEov0hDi0vxZnEwU0HXtWGwQR4I74tjGvmOxnuFHy1mNOCk3S64AYN3CCk4t
 Accept: application/json
-Content-Length: 47
+Content-Length: 45
 Host: localhost:8080
 
 {
@@ -3075,7 +3075,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: SAMEORIGIN
-Content-Length: 253
+Content-Length: 243
 
 {
   "commentId" : 4,
@@ -3098,7 +3098,7 @@ Content-Length: 253
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/galleries/comments/3/replies/3' -i -X DELETE \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY2OTk1ODM3MiwiZXhwIjoxNjcwMDQ0NzcyfQ.M1nJgq-CejjvSFDmSBv1-oTOiY2StHCx_Io_fJUlqbCjH6CuI0HKgBkWNrf4lHlh' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY3MDA4NDkzNCwiZXhwIjoxNjcwMDg1NTM0fQ.W3HjRKGEdlWuc0LxQo3TY6hFqlew-WDgR40KXsu08KxAspX6aNhyKJRHuud18Plt' \
     -H 'Accept: application/json'</code></pre>
 </div>
 </div>
@@ -3107,7 +3107,7 @@ Content-Length: 253
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /galleries/comments/3/replies/3 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY2OTk1ODM3MiwiZXhwIjoxNjcwMDQ0NzcyfQ.M1nJgq-CejjvSFDmSBv1-oTOiY2StHCx_Io_fJUlqbCjH6CuI0HKgBkWNrf4lHlh
+Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY3MDA4NDkzNCwiZXhwIjoxNjcwMDg1NTM0fQ.W3HjRKGEdlWuc0LxQo3TY6hFqlew-WDgR40KXsu08KxAspX6aNhyKJRHuud18Plt
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -3183,7 +3183,7 @@ X-Frame-Options: SAMEORIGIN</code></pre>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/members/me/alarms?page=1&amp;filter=ALL' -i -X GET \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNjYsImV4cCI6MTY3MDA0NDc2Nn0.4rqXh3vYmJHj8NHb5CL1btIDMP2xzqrEaF_-Cj-Xg6ua7Bq4P9_EG6NzkByezwqw' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzAsImV4cCI6MTY3MDA4NTUzMH0.HZUNlTDeYFNBc5QaU8vmxv9dY6PzbWN2Vwz5OhLObesB49khpb9he0QI1fLjmjQV' \
     -H 'Accept: application/json'</code></pre>
 </div>
 </div>
@@ -3192,7 +3192,7 @@ X-Frame-Options: SAMEORIGIN</code></pre>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /members/me/alarms?page=1&amp;filter=ALL HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2Njk5NTgzNjYsImV4cCI6MTY3MDA0NDc2Nn0.4rqXh3vYmJHj8NHb5CL1btIDMP2xzqrEaF_-Cj-Xg6ua7Bq4P9_EG6NzkByezwqw
+Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjoxMCwidXNlcm5hbWUiOiJ0ZXN0MUBnbWFpbC5jb20iLCJzdWIiOiJ0ZXN0MUBnbWFpbC5jb20iLCJpYXQiOjE2NzAwODQ5MzAsImV4cCI6MTY3MDA4NTUzMH0.HZUNlTDeYFNBc5QaU8vmxv9dY6PzbWN2Vwz5OhLObesB49khpb9he0QI1fLjmjQV
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -3253,13 +3253,13 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: SAMEORIGIN
-Content-Length: 668
+Content-Length: 641
 
 [ {
   "alarmId" : 2,
   "alarmType" : "POST_ARTWORK",
   "userNickname" : "행위유저 1",
-  "createdAt" : "2022-12-02T14:19:26.3200758",
+  "createdAt" : "2022-12-04T01:28:50.357969",
   "read" : false,
   "artworkId" : 1,
   "artworkTitle" : "Test 작품 입니다."
@@ -3267,7 +3267,7 @@ Content-Length: 668
   "alarmId" : 3,
   "alarmType" : "LIKE_ARTWORK",
   "userNickname" : "행위유저 2",
-  "createdAt" : "2022-12-02T14:19:26.3210763",
+  "createdAt" : "2022-12-04T01:28:50.359299",
   "read" : false,
   "artworkId" : 1,
   "artworkTitle" : "Test 작품 입니다."
@@ -3275,7 +3275,7 @@ Content-Length: 668
   "alarmId" : 4,
   "alarmType" : "COMMENT_GALLERY",
   "userNickname" : "행위유저 3",
-  "createdAt" : "2022-12-02T14:19:26.3220756",
+  "createdAt" : "2022-12-04T01:28:50.360578",
   "read" : true,
   "artworkId" : null,
   "artworkTitle" : null
@@ -3290,7 +3290,7 @@ Content-Length: 668
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/members/me/alarms/read' -i -X GET \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY2OTk1ODM2NSwiZXhwIjoxNjcwMDQ0NzY1fQ.9d5sDa0PPJCOlI5BZCl-PF7jxAbT-fs633PsEwTaxrwV1LxEmpEC6Jjgr0FFowRr' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY3MDA4NDkzMCwiZXhwIjoxNjcwMDg1NTMwfQ._h8uSlN8lbKWS49G-5-S1JtaNlIruz6i_xI3YIpgWAdVFThsaF-W2HZAFC5HQgrW' \
     -H 'Accept: application/json'</code></pre>
 </div>
 </div>
@@ -3299,7 +3299,7 @@ Content-Length: 668
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /members/me/alarms/read HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY2OTk1ODM2NSwiZXhwIjoxNjcwMDQ0NzY1fQ.9d5sDa0PPJCOlI5BZCl-PF7jxAbT-fs633PsEwTaxrwV1LxEmpEC6Jjgr0FFowRr
+Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiVVNFUiIsImlkIjo5LCJ1c2VybmFtZSI6InRlc3QxQGdtYWlsLmNvbSIsInN1YiI6InRlc3QxQGdtYWlsLmNvbSIsImlhdCI6MTY3MDA4NDkzMCwiZXhwIjoxNjcwMDg1NTMwfQ._h8uSlN8lbKWS49G-5-S1JtaNlIruz6i_xI3YIpgWAdVFThsaF-W2HZAFC5HQgrW
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -3337,7 +3337,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: SAMEORIGIN
-Content-Length: 81
+Content-Length: 78
 
 {
   "readAlarmExist" : false,
@@ -3352,7 +3352,7 @@ Content-Length: 81
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-12-02 10:40:39 +0900
+Last updated 2022-12-02 18:09:50 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.min.css">

--- a/server/oneyearfourcut/src/test/java/com/codestates/mainproject/oneyearfourcut/domain/member/controller/MemberControllerRestDocsTest.java
+++ b/server/oneyearfourcut/src/test/java/com/codestates/mainproject/oneyearfourcut/domain/member/controller/MemberControllerRestDocsTest.java
@@ -3,6 +3,7 @@ package com.codestates.mainproject.oneyearfourcut.domain.member.controller;
 import com.codestates.mainproject.oneyearfourcut.domain.gallery.entity.Gallery;
 import com.codestates.mainproject.oneyearfourcut.domain.gallery.entity.GalleryStatus;
 import com.codestates.mainproject.oneyearfourcut.domain.gallery.repository.GalleryRepository;
+import com.codestates.mainproject.oneyearfourcut.domain.gallery.service.GalleryService;
 import com.codestates.mainproject.oneyearfourcut.domain.member.entity.Member;
 import com.codestates.mainproject.oneyearfourcut.domain.member.entity.MemberStatus;
 import com.codestates.mainproject.oneyearfourcut.domain.member.entity.Role;
@@ -32,7 +33,9 @@ import java.util.List;
 import static com.codestates.mainproject.oneyearfourcut.global.util.ApiDocumentUtils.getRequestPreProcessor;
 import static com.codestates.mainproject.oneyearfourcut.global.util.ApiDocumentUtils.getResponsePreProcessor;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -61,6 +64,8 @@ class MemberControllerRestDocsTest {
     private AwsS3Service awsS3Service;
     @MockBean
     private RestTemplate restTemplate;
+    @MockBean
+    private GalleryService galleryService;
 
     @Test
     void getMember() throws Exception {
@@ -184,6 +189,7 @@ class MemberControllerRestDocsTest {
         given(restTemplate.exchange(any(RequestEntity.class), any(Class.class)))
                 .willReturn(responseEntity);
 
+        willDoNothing().given(galleryService).deleteGallery(anyLong());
         //when
         ResultActions actions = mockMvc.perform(
                 delete("/members/me")

--- a/server/oneyearfourcut/src/test/java/com/codestates/mainproject/oneyearfourcut/domain/member/controller/MemberControllerRestDocsTest.java
+++ b/server/oneyearfourcut/src/test/java/com/codestates/mainproject/oneyearfourcut/domain/member/controller/MemberControllerRestDocsTest.java
@@ -16,11 +16,15 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -55,6 +59,8 @@ class MemberControllerRestDocsTest {
     private Gson gson;
     @MockBean
     private AwsS3Service awsS3Service;
+    @MockBean
+    private RestTemplate restTemplate;
 
     @Test
     void getMember() throws Exception {
@@ -167,10 +173,16 @@ class MemberControllerRestDocsTest {
                 .profile("/path")
                 .role(Role.USER)
                 .status(MemberStatus.ACTIVE)
+                        .kakaoId(41234L)
                 .build());
 
         //해당 member jwt 생성
         String jwt = jwtTokenizer.testJwtGenerator(member);
+
+        //kakao 연결끊기 given 처리
+        ResponseEntity responseEntity = new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        given(restTemplate.exchange(any(RequestEntity.class), any(Class.class)))
+                .willReturn(responseEntity);
 
         //when
         ResultActions actions = mockMvc.perform(

--- a/server/oneyearfourcut/src/test/java/com/codestates/mainproject/oneyearfourcut/domain/refreshToken/controller/RefreshTokenControllerRestDocsTest.java
+++ b/server/oneyearfourcut/src/test/java/com/codestates/mainproject/oneyearfourcut/domain/refreshToken/controller/RefreshTokenControllerRestDocsTest.java
@@ -84,7 +84,7 @@ class RefreshTokenControllerRestDocsTest {
         given(refreshTokenService.findRefreshTokenByEmail(anyString()))
                 .willReturn(token);
         given(jwtTokenizer.generateAccessToken(any(Claims.class), anyString(), anyString()))
-                .willReturn("Bearer " + jwt);
+                .willReturn(jwt);
         given(jwtTokenizer.generateRefreshToken(anyString(), anyString()))
                 .willReturn(jwt);
         given(jwtTokenizer.isExpiredToken(anyString(), anyString()))

--- a/server/oneyearfourcut/src/test/resources/application.yml
+++ b/server/oneyearfourcut/src/test/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create  # 스키마 자동 생성
+    show-sql: true      # SQL 쿼리 출력
+    defer-datasource-initialization: true
+  profiles:
+    include: oauth
+  sql:
+    init:
+      data-locations: classpath*:db/testdata.sql

--- a/server/oneyearfourcut/src/test/resources/db/testdata.sql
+++ b/server/oneyearfourcut/src/test/resources/db/testdata.sql
@@ -1,0 +1,43 @@
+INSERT INTO MEMBER (nickname, email, created_at, last_modified_at, status, role) VALUES
+('galleryPerson', 'test1@gmail.com', '2022-11-16T23:41:57.764644', '2022-11-16T23:41:57.764644', 'ACTIVE', 'USER'),
+('artworkPerson1', 'artworkPerson1@gmail.com', '2022-11-16T23:41:57.764644', '2022-11-16T23:41:57.764644', 'ACTIVE', 'USER'),
+('commentPerson', 'test3@gmail.com', '2022-11-16T23:41:57.764644', '2022-11-16T23:41:57.764644', 'ACTIVE', 'USER'),
+('replyPerson', 'test4@gmail.com', '2022-11-16T23:41:57.764644', '2022-11-16T23:41:57.764644', 'ACTIVE', 'USER'),
+('votePerson', 'test5@gmail.com', '2022-11-16T23:41:57.764644', '2022-11-16T23:41:57.764644', 'ACTIVE', 'USER'),
+('artworkPerson2', 'artworkPerson2@gmail.com', '2022-11-16T23:41:57.764644', '2022-11-16T23:41:57.764644', 'ACTIVE', 'USER'),
+('artworkPerson3', 'artworkPerson3@gmail.com', '2022-11-16T23:41:57.764644', '2022-11-16T23:41:57.764644', 'ACTIVE', 'USER'),
+('artworkPerson4', 'artworkPerson4@gmail.com', '2022-11-16T23:41:57.764644', '2022-11-16T23:41:57.764644', 'ACTIVE', 'USER');
+
+INSERT INTO GALLERY (title, content ,created_at, last_modified_at, member_id, status) values
+('commentPerson님의 전시관', '설명글', '2022-11-16T23:41:57.764644', '2022-11-16T23:41:57.764644', 3, 'OPEN'),
+('galleryPerson님의 전시관', '설명글', '2022-11-16T23:41:57.764644', '2022-11-16T23:41:57.764644', 1, 'OPEN');
+
+INSERT INTO ARTWORK (title, content, image_path, status, created_at, last_modified_at ,gallery_id, member_id) values
+('갤러리1-작품1', '다들 화이팅입니다!', '/1.jpg', 'REGISTRATION', '2022-11-16T23:41:57.764644', '2022-11-16T23:41:57.764644', 1, 2),
+('갤러리1-작품2', '다들 화이팅입니다!', '/2.jpg', 'REGISTRATION', '2022-11-16T23:42:57.764644', '2022-11-16T23:42:57.764644', 1, 6),
+('갤러리1-작품3', '다들 화이팅입니다!', '/3.jpg', 'REGISTRATION', '2022-11-16T23:43:57.764644', '2022-11-16T23:43:57.764644', 1, 7),
+('갤러리1-작품4', '다들 화이팅입니다!', '/4.jpg', 'REGISTRATION', '2022-11-16T23:44:57.764644', '2022-11-16T23:44:57.764644', 1, 8),
+('갤러리2-작품1', '다들 화이팅입니다!', '/4.jpg', 'REGISTRATION', '2022-11-16T23:45:57.764644', '2022-11-16T23:45:57.764644', 2, 8),
+('갤러리2-작품2', '다들 화이팅입니다!', '/4.jpg', 'REGISTRATION', '2022-11-16T23:46:57.764644', '2022-11-16T23:46:57.764644', 2, 8);
+
+INSERT INTO COMMENT (content ,created_at, last_modified_at, artwork_id, gallery_id, member_id, COMMENT_STATUS) values
+('comment1댓글대스', '2022-11-11T23:41:57.764644', '2022-11-16T23:41:57.764644', 1, 1, 1, 'VALID'),
+('comment2', '2022-11-12T23:41:58.764644', '2022-11-16T23:41:57.764644', 2, 1, 1, 'VALID'),
+('comment3', '2022-11-13T23:41:59.764644', '2022-11-16T23:41:57.764644', 3, 1, 2, 'DELETED'),
+('comment444', '2022-11-14T23:41:52.764644', '2022-11-16T23:41:57.764644', null, 1, 4, 'VALID');
+
+
+INSERT INTO REPLY (content ,created_at, last_modified_at, comment_id, member_id, Reply_STATUS) values
+('대댓글', '2022-11-11T23:41:57.764644', '2022-11-16T23:41:57.764644', 1, 1, 'VALID'),
+('대댓글22', '2022-11-12T23:41:58.764644', '2022-11-16T23:41:57.764644', 1, 1, 'VALID'),
+('대댓글33', '2022-11-13T23:41:59.764644', '2022-11-16T23:41:57.764644', 1, 2, 'DELETED'),
+('대댓글455', '2022-11-14T23:41:52.764644', '2022-11-16T23:41:57.764644', 1, 4, 'VALID');
+
+INSERT INTO ARTWORK_LIKE (member_id, artwork_id, status, created_at, last_modified_at) values
+(1, 4, 'LIKE', '2022-11-11T23:41:57.764644', '2022-11-16T23:41:57.764644'),
+(2, 4, 'LIKE', '2022-11-11T23:42:57.764644', '2022-11-16T23:42:57.764644'),
+(3, 4, 'LIKE', '2022-11-11T23:43:57.764644', '2022-11-16T23:43:57.764644'),
+(1, 3, 'LIKE', '2022-11-11T23:44:57.764644', '2022-11-16T23:44:57.764644'),
+(2, 3, 'LIKE', '2022-11-11T23:45:57.764644', '2022-11-16T23:45:57.764644');
+
+


### PR DESCRIPTION
1. 회원 탈퇴 시 카카오와의 연결을 끊는 로직을 추가했습니다.
2. 회원 탈퇴 시 오픈된 전시가 있으면 함께 폐쇄되도록 구현했습니다.
3. 카카오로 api요청을 보내기위해 restTemplate을 빈으로 등록했습니다.
4. test 환경을 분리하기위해 test/resources에 application.yml 과 testdata.sql을 추가했습니다.
5. 이미 탈퇴 했던 회원이 다시 회원 가입하는 경우 status를 ACTIVE로 바꾸는 로직을 추가했습니다.